### PR TITLE
Fixes/thread safety

### DIFF
--- a/src/main/java/synth/core/Synthesiser.java
+++ b/src/main/java/synth/core/Synthesiser.java
@@ -56,8 +56,13 @@ public class Synthesiser{
     // Panning
     private volatile double panDepth;
 
-    // Dirty flag: setters set true, audio thread clears after syncing to voices
-    private volatile boolean paramsDirty = false;
+    // Granular dirty flags: setters set per-group flag, audio thread clears after syncing to voices
+    private volatile boolean waveformDirty = false;
+    private volatile boolean filterDirty = false;
+    private volatile boolean filterEnvDirty = false;
+    private volatile boolean ampEnvDirty = false;
+    private volatile boolean gainDirty = false;
+    private volatile boolean panDirty = false;
 
     // Output Buffers
     int blockSize;
@@ -140,7 +145,7 @@ public class Synthesiser{
     public void setOscillatorWaveform(Waveform waveform){
         if (this.waveform != waveform){
             this.waveform = waveform;
-            this.paramsDirty = true;
+            this.waveformDirty = true;
         }
     }
 
@@ -155,67 +160,67 @@ public class Synthesiser{
 
     public void setFilterCutoff(double cutoff) {
         this.filterCutoff = Math.max(20.0, Math.min(20000.0, cutoff)); // Clamp to audible range
-        this.paramsDirty = true;
+        this.filterDirty = true;
     }
 
     public void setFilterResonance(double resonance) {
         this.filterResonance = Math.max(1.0, Math.min(20.0, resonance)); // Clamp from 1 to 20
-        this.paramsDirty = true;
+        this.filterDirty = true;
     }
 
     public void setFilterModRange(double modRange) {
         this.filterModRange = Math.max(0.0, modRange);
-        this.paramsDirty = true;
+        this.filterDirty = true;
     }
 
     public void setFilterAttackTime(double seconds) {
         this.filterAttackTime = Math.max(0.0, seconds);
-        this.paramsDirty = true;
+        this.filterEnvDirty = true;
     }
 
     public void setFilterDecayTime(double seconds) {
         this.filterDecayTime = Math.max(0.0, seconds);
-        this.paramsDirty = true;
+        this.filterEnvDirty = true;
     }
 
     public void setFilterSustainLevel(double level) {
         this.filterSustainLevel = Math.max(0.0, Math.min(1.0, level));
-        this.paramsDirty = true;
+        this.filterEnvDirty = true;
     }
 
     public void setFilterReleaseTime(double seconds) {
         this.filterReleaseTime = Math.max(0.0, seconds);
-        this.paramsDirty = true;
+        this.filterEnvDirty = true;
     }
 
     public void setAmpAttackTime(double seconds) {
         this.ampAttackTime = Math.max(0.0, seconds);
-        this.paramsDirty = true;
+        this.ampEnvDirty = true;
     }
 
     public void setAmpDecayTime(double seconds) {
         this.ampDecayTime = Math.max(0.0, seconds);
-        this.paramsDirty = true;
+        this.ampEnvDirty = true;
     }
 
     public void setAmpSustainLevel(double level) {
         this.ampSustainLevel = Math.max(0.0, Math.min(1.0, level));
-        this.paramsDirty = true;
+        this.ampEnvDirty = true;
     }
 
     public void setAmpReleaseTime(double seconds) {
         this.ampReleaseTime = Math.max(0.0, seconds);
-        this.paramsDirty = true;
+        this.ampEnvDirty = true;
     }
 
     public void setPreFilterGainDB(double db) {
         this.preFilterGainDB = db;
-        this.paramsDirty = true;
+        this.gainDirty = true;
     }
 
     public void setPostFilterGainDB(double db) {
         this.postFilterGainDB = db;
-        this.paramsDirty = true;
+        this.gainDirty = true;
     }
 
     public void setLFOFrequency(double frequency) {
@@ -224,7 +229,7 @@ public class Synthesiser{
 
     public void setPanDepth(double depth) {
         this.panDepth = Math.max(0.0, Math.min(1.0, depth));
-        this.paramsDirty = true;
+        this.panDirty = true;
     }
 
     public void setMasterVolume(double volumeScalar){
@@ -432,11 +437,29 @@ public class Synthesiser{
 
         // Voice Processing and Mixing
         synchronized (voices) {
-            // Pull model: sync parameters to voices when any setter has fired
-            if (this.paramsDirty) {
-                this.paramsDirty = false;
+            // Pull model: sync only dirty parameter groups to voices
+            boolean wf = this.waveformDirty;
+            boolean fi = this.filterDirty;
+            boolean fe = this.filterEnvDirty;
+            boolean ae = this.ampEnvDirty;
+            boolean ga = this.gainDirty;
+            boolean pa = this.panDirty;
+
+            if (wf || fi || fe || ae || ga || pa) {
+                if (wf) this.waveformDirty = false;
+                if (fi) this.filterDirty = false;
+                if (fe) this.filterEnvDirty = false;
+                if (ae) this.ampEnvDirty = false;
+                if (ga) this.gainDirty = false;
+                if (pa) this.panDirty = false;
+
                 for (int i = 0; i < voices.length; i++) {
-                    setVoiceParams(voices[i]);
+                    if (wf) voices[i].setOscillatorWaveform(this.waveform);
+                    if (fi) voices[i].setFilterParameters(this.filterCutoff, this.filterResonance, this.filterModRange);
+                    if (fe) voices[i].setFilterEnvelope(this.filterAttackTime, this.filterDecayTime, this.filterSustainLevel, this.filterReleaseTime);
+                    if (ae) voices[i].setAmpEnvelope(this.ampAttackTime, this.ampDecayTime, this.ampSustainLevel, this.ampReleaseTime);
+                    if (ga) voices[i].setFilterGainStaging(this.preFilterGainDB, this.postFilterGainDB);
+                    if (pa) voices[i].setPanDepth(this.panDepth);
                 }
             }
 
@@ -494,11 +517,29 @@ public class Synthesiser{
         // Voice Processing and Mixing
         startTime = System.nanoTime();
         synchronized (voices) {
-            // Pull model: sync parameters to voices when any setter has fired
-            if (this.paramsDirty) {
-                this.paramsDirty = false;
+            // Pull model: sync only dirty parameter groups to voices
+            boolean wf = this.waveformDirty;
+            boolean fi = this.filterDirty;
+            boolean fe = this.filterEnvDirty;
+            boolean ae = this.ampEnvDirty;
+            boolean ga = this.gainDirty;
+            boolean pa = this.panDirty;
+
+            if (wf || fi || fe || ae || ga || pa) {
+                if (wf) this.waveformDirty = false;
+                if (fi) this.filterDirty = false;
+                if (fe) this.filterEnvDirty = false;
+                if (ae) this.ampEnvDirty = false;
+                if (ga) this.gainDirty = false;
+                if (pa) this.panDirty = false;
+
                 for (int i = 0; i < voices.length; i++) {
-                    setVoiceParams(voices[i]);
+                    if (wf) voices[i].setOscillatorWaveform(this.waveform);
+                    if (fi) voices[i].setFilterParameters(this.filterCutoff, this.filterResonance, this.filterModRange);
+                    if (fe) voices[i].setFilterEnvelope(this.filterAttackTime, this.filterDecayTime, this.filterSustainLevel, this.filterReleaseTime);
+                    if (ae) voices[i].setAmpEnvelope(this.ampAttackTime, this.ampDecayTime, this.ampSustainLevel, this.ampReleaseTime);
+                    if (ga) voices[i].setFilterGainStaging(this.preFilterGainDB, this.postFilterGainDB);
+                    if (pa) voices[i].setPanDepth(this.panDepth);
                 }
             }
 

--- a/src/main/java/synth/core/Synthesiser.java
+++ b/src/main/java/synth/core/Synthesiser.java
@@ -85,6 +85,9 @@ public class Synthesiser{
         if (noVoices <= 0) {
             throw new IllegalArgumentException("Number of voices must be positive.");
         }
+        if (sampleRate <= 40.0) {
+            throw new IllegalArgumentException("Sample rate must be greater than 40 Hz.");
+        }
         this.sampleRate = sampleRate;
         this.voiceSumAttenuation = 1.0 / Math.sqrt(noVoices);
         this.volumeAttenuation = this.voiceSumAttenuation;
@@ -192,7 +195,9 @@ public class Synthesiser{
     }
 
     public void setFilterModRange(double modRange) {
-        double clamped = Math.max(0.0, modRange);
+        double nyquistLimit = (this.sampleRate / 2.0) - 1.0;
+        double maxModRange = Math.max(0.0, Math.nextDown(nyquistLimit) - this.filterCutoff);
+        double clamped = Math.max(0.0, Math.min(modRange, maxModRange));
         if (Double.compare(this.filterModRange, clamped) != 0) {
             this.filterModRange = clamped;
             this.filterDirty.set(true);
@@ -476,13 +481,10 @@ public class Synthesiser{
     }
 
     /**
-     * Processes one block of audio samples for all active voices.
+     * Syncs LFO oscillator selection and frequency from volatile fields.
+     * Must only be called from the audio thread.
      */
-    public void processBlock(double[] stereoOutputBuffer){
-        // Clear the output buffer
-        Arrays.fill(stereoOutputBuffer, 0.0);
-
-        // Sync LFO settings from volatile fields (audio thread is sole consumer of LFO object)
+    private void syncLfo() {
         switch (this.LFOWaveForm) {
             case SINE -> this.LFO = this.sineLFO;
             case SAW -> this.LFO = this.sawLFO;
@@ -490,6 +492,47 @@ public class Synthesiser{
             case SQUARE -> this.LFO = this.squareLFO;
         }
         this.LFO.setFrequency(this.LFOFrequency);
+    }
+
+    /**
+     * Atomically reads and clears dirty flags, then applies changed parameter
+     * groups to all voices. Must be called while holding the voices lock.
+     */
+    private void syncDirtyParamsToVoices() {
+        boolean wf = this.waveformDirty.getAndSet(false);
+        boolean fi = this.filterDirty.getAndSet(false);
+        boolean fe = this.filterEnvDirty.getAndSet(false);
+        boolean ae = this.ampEnvDirty.getAndSet(false);
+        boolean ga = this.gainDirty.getAndSet(false);
+        boolean pa = this.panDirty.getAndSet(false);
+
+        if (wf || fi || fe || ae || ga || pa) {
+            Waveform wfSnap = wf ? this.waveform : null;
+            double fcSnap = this.filterCutoff, frSnap = this.filterResonance, fmrSnap = this.filterModRange;
+            double faSnap = this.filterAttackTime, fdSnap = this.filterDecayTime, fsSnap = this.filterSustainLevel, frTSnap = this.filterReleaseTime;
+            double aaSnap = this.ampAttackTime, adSnap = this.ampDecayTime, asSnap = this.ampSustainLevel, arSnap = this.ampReleaseTime;
+            double pfgSnap = this.preFilterGainDB, pfgPostSnap = this.postFilterGainDB;
+            double pdSnap = this.panDepth;
+
+            for (int i = 0; i < voices.length; i++) {
+                if (wf) voices[i].setOscillatorWaveform(wfSnap);
+                if (fi) voices[i].setFilterParameters(fcSnap, frSnap, fmrSnap);
+                if (fe) voices[i].setFilterEnvelope(faSnap, fdSnap, fsSnap, frTSnap);
+                if (ae) voices[i].setAmpEnvelope(aaSnap, adSnap, asSnap, arSnap);
+                if (ga) voices[i].setFilterGainStaging(pfgSnap, pfgPostSnap);
+                if (pa) voices[i].setPanDepth(pdSnap);
+            }
+        }
+    }
+
+    /**
+     * Processes one block of audio samples for all active voices.
+     */
+    public void processBlock(double[] stereoOutputBuffer){
+        // Clear the output buffer
+        Arrays.fill(stereoOutputBuffer, 0.0);
+
+        syncLfo();
 
         // Populate LFO buffer
         LFO.processBlock(null, this.lfoOutputBuffer, blockSize);
@@ -498,32 +541,7 @@ public class Synthesiser{
 
         // Voice Processing and Mixing
         synchronized (voices) {
-            // Pull model: sync only dirty parameter groups to voices (atomic read+clear)
-            boolean wf = this.waveformDirty.getAndSet(false);
-            boolean fi = this.filterDirty.getAndSet(false);
-            boolean fe = this.filterEnvDirty.getAndSet(false);
-            boolean ae = this.ampEnvDirty.getAndSet(false);
-            boolean ga = this.gainDirty.getAndSet(false);
-            boolean pa = this.panDirty.getAndSet(false);
-
-            if (wf || fi || fe || ae || ga || pa) {
-                // Snapshot volatile fields into locals for consistent per-block updates
-                Waveform wfSnap = wf ? this.waveform : null;
-                double fcSnap = this.filterCutoff, frSnap = this.filterResonance, fmrSnap = this.filterModRange;
-                double faSnap = this.filterAttackTime, fdSnap = this.filterDecayTime, fsSnap = this.filterSustainLevel, frTSnap = this.filterReleaseTime;
-                double aaSnap = this.ampAttackTime, adSnap = this.ampDecayTime, asSnap = this.ampSustainLevel, arSnap = this.ampReleaseTime;
-                double pfgSnap = this.preFilterGainDB, pfgPostSnap = this.postFilterGainDB;
-                double pdSnap = this.panDepth;
-
-                for (int i = 0; i < voices.length; i++) {
-                    if (wf) voices[i].setOscillatorWaveform(wfSnap);
-                    if (fi) voices[i].setFilterParameters(fcSnap, frSnap, fmrSnap);
-                    if (fe) voices[i].setFilterEnvelope(faSnap, fdSnap, fsSnap, frTSnap);
-                    if (ae) voices[i].setAmpEnvelope(aaSnap, adSnap, asSnap, arSnap);
-                    if (ga) voices[i].setFilterGainStaging(pfgSnap, pfgPostSnap);
-                    if (pa) voices[i].setPanDepth(pdSnap);
-                }
-            }
+            syncDirtyParamsToVoices();
 
             for (int i = 0; i < voices.length; i++) {
                 Voice voice = voices[i];
@@ -561,14 +579,7 @@ public class Synthesiser{
         timings.clear();
         Arrays.fill(stereoOutputBuffer, 0.0);
 
-        // Sync LFO settings from volatile fields (audio thread is sole consumer of LFO object)
-        switch (this.LFOWaveForm) {
-            case SINE -> this.LFO = this.sineLFO;
-            case SAW -> this.LFO = this.sawLFO;
-            case TRIANGLE -> this.LFO = this.triangleLFO;
-            case SQUARE -> this.LFO = this.squareLFO;
-        }
-        this.LFO.setFrequency(this.LFOFrequency);
+        syncLfo();
 
         // Populate LFO buffer
         startTime = System.nanoTime();
@@ -581,32 +592,7 @@ public class Synthesiser{
         // Voice Processing and Mixing
         startTime = System.nanoTime();
         synchronized (voices) {
-            // Pull model: sync only dirty parameter groups to voices (atomic read+clear)
-            boolean wf = this.waveformDirty.getAndSet(false);
-            boolean fi = this.filterDirty.getAndSet(false);
-            boolean fe = this.filterEnvDirty.getAndSet(false);
-            boolean ae = this.ampEnvDirty.getAndSet(false);
-            boolean ga = this.gainDirty.getAndSet(false);
-            boolean pa = this.panDirty.getAndSet(false);
-
-            if (wf || fi || fe || ae || ga || pa) {
-                // Snapshot volatile fields into locals for consistent per-block updates
-                Waveform wfSnap = wf ? this.waveform : null;
-                double fcSnap = this.filterCutoff, frSnap = this.filterResonance, fmrSnap = this.filterModRange;
-                double faSnap = this.filterAttackTime, fdSnap = this.filterDecayTime, fsSnap = this.filterSustainLevel, frTSnap = this.filterReleaseTime;
-                double aaSnap = this.ampAttackTime, adSnap = this.ampDecayTime, asSnap = this.ampSustainLevel, arSnap = this.ampReleaseTime;
-                double pfgSnap = this.preFilterGainDB, pfgPostSnap = this.postFilterGainDB;
-                double pdSnap = this.panDepth;
-
-                for (int i = 0; i < voices.length; i++) {
-                    if (wf) voices[i].setOscillatorWaveform(wfSnap);
-                    if (fi) voices[i].setFilterParameters(fcSnap, frSnap, fmrSnap);
-                    if (fe) voices[i].setFilterEnvelope(faSnap, fdSnap, fsSnap, frTSnap);
-                    if (ae) voices[i].setAmpEnvelope(aaSnap, adSnap, asSnap, arSnap);
-                    if (ga) voices[i].setFilterGainStaging(pfgSnap, pfgPostSnap);
-                    if (pa) voices[i].setPanDepth(pdSnap);
-                }
-            }
+            syncDirtyParamsToVoices();
 
             for (int i = 0; i < voices.length; i++) {
                 Voice voice = voices[i];

--- a/src/main/java/synth/core/Synthesiser.java
+++ b/src/main/java/synth/core/Synthesiser.java
@@ -1,10 +1,15 @@
 package synth.core;
 
-import synth.components.oscillators.*;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import synth.components.oscillators.Oscillator;
+import synth.components.oscillators.SawOscillator;
+import synth.components.oscillators.SineOscillator;
+import synth.components.oscillators.SquareOscillator;
+import synth.components.oscillators.TriangleOscillator;
 
 /**
  * The main synthesiser class that manages and processes multiple voices.
@@ -169,7 +174,8 @@ public class Synthesiser{
     }
 
     public void setFilterCutoff(double cutoff) {
-        double maxCutoff = (this.sampleRate / 2.0) - 1.0;
+        double nyquistLimit = (this.sampleRate / 2.0) - 1.0;
+        double maxCutoff = Math.nextDown(nyquistLimit);
         this.filterCutoff = Math.max(20.0, Math.min(maxCutoff, cutoff));
         this.filterDirty.set(true);
     }

--- a/src/main/java/synth/core/Synthesiser.java
+++ b/src/main/java/synth/core/Synthesiser.java
@@ -176,68 +176,105 @@ public class Synthesiser{
     public void setFilterCutoff(double cutoff) {
         double nyquistLimit = (this.sampleRate / 2.0) - 1.0;
         double maxCutoff = Math.nextDown(nyquistLimit);
-        this.filterCutoff = Math.max(20.0, Math.min(maxCutoff, cutoff));
-        this.filterDirty.set(true);
+        double clamped = Math.max(20.0, Math.min(maxCutoff, cutoff));
+        if (Double.compare(this.filterCutoff, clamped) != 0) {
+            this.filterCutoff = clamped;
+            this.filterDirty.set(true);
+        }
     }
 
     public void setFilterResonance(double resonance) {
-        this.filterResonance = Math.max(1.0, Math.min(20.0, resonance)); // Clamp from 1 to 20
-        this.filterDirty.set(true);
+        double clamped = Math.max(1.0, Math.min(20.0, resonance));
+        if (Double.compare(this.filterResonance, clamped) != 0) {
+            this.filterResonance = clamped;
+            this.filterDirty.set(true);
+        }
     }
 
     public void setFilterModRange(double modRange) {
-        this.filterModRange = Math.max(0.0, modRange);
-        this.filterDirty.set(true);
+        double clamped = Math.max(0.0, modRange);
+        if (Double.compare(this.filterModRange, clamped) != 0) {
+            this.filterModRange = clamped;
+            this.filterDirty.set(true);
+        }
     }
 
     public void setFilterAttackTime(double seconds) {
-        this.filterAttackTime = Math.max(0.0, seconds);
-        this.filterEnvDirty.set(true);
+        double clamped = Math.max(0.0, seconds);
+        if (Double.compare(this.filterAttackTime, clamped) != 0) {
+            this.filterAttackTime = clamped;
+            this.filterEnvDirty.set(true);
+        }
     }
 
     public void setFilterDecayTime(double seconds) {
-        this.filterDecayTime = Math.max(0.0, seconds);
-        this.filterEnvDirty.set(true);
+        double clamped = Math.max(0.0, seconds);
+        if (Double.compare(this.filterDecayTime, clamped) != 0) {
+            this.filterDecayTime = clamped;
+            this.filterEnvDirty.set(true);
+        }
     }
 
     public void setFilterSustainLevel(double level) {
-        this.filterSustainLevel = Math.max(0.0, Math.min(1.0, level));
-        this.filterEnvDirty.set(true);
+        double clamped = Math.max(0.0, Math.min(1.0, level));
+        if (Double.compare(this.filterSustainLevel, clamped) != 0) {
+            this.filterSustainLevel = clamped;
+            this.filterEnvDirty.set(true);
+        }
     }
 
     public void setFilterReleaseTime(double seconds) {
-        this.filterReleaseTime = Math.max(0.0, seconds);
-        this.filterEnvDirty.set(true);
+        double clamped = Math.max(0.0, seconds);
+        if (Double.compare(this.filterReleaseTime, clamped) != 0) {
+            this.filterReleaseTime = clamped;
+            this.filterEnvDirty.set(true);
+        }
     }
 
     public void setAmpAttackTime(double seconds) {
-        this.ampAttackTime = Math.max(0.0, seconds);
-        this.ampEnvDirty.set(true);
+        double clamped = Math.max(0.0, seconds);
+        if (Double.compare(this.ampAttackTime, clamped) != 0) {
+            this.ampAttackTime = clamped;
+            this.ampEnvDirty.set(true);
+        }
     }
 
     public void setAmpDecayTime(double seconds) {
-        this.ampDecayTime = Math.max(0.0, seconds);
-        this.ampEnvDirty.set(true);
+        double clamped = Math.max(0.0, seconds);
+        if (Double.compare(this.ampDecayTime, clamped) != 0) {
+            this.ampDecayTime = clamped;
+            this.ampEnvDirty.set(true);
+        }
     }
 
     public void setAmpSustainLevel(double level) {
-        this.ampSustainLevel = Math.max(0.0, Math.min(1.0, level));
-        this.ampEnvDirty.set(true);
+        double clamped = Math.max(0.0, Math.min(1.0, level));
+        if (Double.compare(this.ampSustainLevel, clamped) != 0) {
+            this.ampSustainLevel = clamped;
+            this.ampEnvDirty.set(true);
+        }
     }
 
     public void setAmpReleaseTime(double seconds) {
-        this.ampReleaseTime = Math.max(0.0, seconds);
-        this.ampEnvDirty.set(true);
+        double clamped = Math.max(0.0, seconds);
+        if (Double.compare(this.ampReleaseTime, clamped) != 0) {
+            this.ampReleaseTime = clamped;
+            this.ampEnvDirty.set(true);
+        }
     }
 
     public void setPreFilterGainDB(double db) {
-        this.preFilterGainDB = db;
-        this.gainDirty.set(true);
+        if (Double.compare(this.preFilterGainDB, db) != 0) {
+            this.preFilterGainDB = db;
+            this.gainDirty.set(true);
+        }
     }
 
     public void setPostFilterGainDB(double db) {
-        this.postFilterGainDB = db;
-        this.gainDirty.set(true);
+        if (Double.compare(this.postFilterGainDB, db) != 0) {
+            this.postFilterGainDB = db;
+            this.gainDirty.set(true);
+        }
     }
 
     public void setLFOFrequency(double frequency) {
@@ -245,8 +282,11 @@ public class Synthesiser{
     }
 
     public void setPanDepth(double depth) {
-        this.panDepth = Math.max(0.0, Math.min(1.0, depth));
-        this.panDirty.set(true);
+        double clamped = Math.max(0.0, Math.min(1.0, depth));
+        if (Double.compare(this.panDepth, clamped) != 0) {
+            this.panDepth = clamped;
+            this.panDirty.set(true);
+        }
     }
 
     public void setMasterVolume(double volumeScalar){

--- a/src/main/java/synth/core/Synthesiser.java
+++ b/src/main/java/synth/core/Synthesiser.java
@@ -4,6 +4,7 @@ import synth.components.oscillators.*;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * The main synthesiser class that manages and processes multiple voices.
@@ -59,12 +60,12 @@ public class Synthesiser{
     private volatile double panDepth;
 
     // Granular dirty flags: setters set per-group flag, audio thread clears after syncing to voices
-    private volatile boolean waveformDirty = false;
-    private volatile boolean filterDirty = false;
-    private volatile boolean filterEnvDirty = false;
-    private volatile boolean ampEnvDirty = false;
-    private volatile boolean gainDirty = false;
-    private volatile boolean panDirty = false;
+    private final AtomicBoolean waveformDirty = new AtomicBoolean(false);
+    private final AtomicBoolean filterDirty = new AtomicBoolean(false);
+    private final AtomicBoolean filterEnvDirty = new AtomicBoolean(false);
+    private final AtomicBoolean ampEnvDirty = new AtomicBoolean(false);
+    private final AtomicBoolean gainDirty = new AtomicBoolean(false);
+    private final AtomicBoolean panDirty = new AtomicBoolean(false);
 
     // Output Buffers
     int blockSize;
@@ -149,9 +150,12 @@ public class Synthesiser{
      * @param waveform The new waveform to use.
      */
     public void setOscillatorWaveform(Waveform waveform){
+        if (waveform == null) {
+            throw new IllegalArgumentException("waveform cannot be null");
+        }
         if (this.waveform != waveform){
             this.waveform = waveform;
-            this.waveformDirty = true;
+            this.waveformDirty.set(true);
         }
     }
 
@@ -167,67 +171,67 @@ public class Synthesiser{
     public void setFilterCutoff(double cutoff) {
         double maxCutoff = (this.sampleRate / 2.0) - 1.0;
         this.filterCutoff = Math.max(20.0, Math.min(maxCutoff, cutoff));
-        this.filterDirty = true;
+        this.filterDirty.set(true);
     }
 
     public void setFilterResonance(double resonance) {
         this.filterResonance = Math.max(1.0, Math.min(20.0, resonance)); // Clamp from 1 to 20
-        this.filterDirty = true;
+        this.filterDirty.set(true);
     }
 
     public void setFilterModRange(double modRange) {
         this.filterModRange = Math.max(0.0, modRange);
-        this.filterDirty = true;
+        this.filterDirty.set(true);
     }
 
     public void setFilterAttackTime(double seconds) {
         this.filterAttackTime = Math.max(0.0, seconds);
-        this.filterEnvDirty = true;
+        this.filterEnvDirty.set(true);
     }
 
     public void setFilterDecayTime(double seconds) {
         this.filterDecayTime = Math.max(0.0, seconds);
-        this.filterEnvDirty = true;
+        this.filterEnvDirty.set(true);
     }
 
     public void setFilterSustainLevel(double level) {
         this.filterSustainLevel = Math.max(0.0, Math.min(1.0, level));
-        this.filterEnvDirty = true;
+        this.filterEnvDirty.set(true);
     }
 
     public void setFilterReleaseTime(double seconds) {
         this.filterReleaseTime = Math.max(0.0, seconds);
-        this.filterEnvDirty = true;
+        this.filterEnvDirty.set(true);
     }
 
     public void setAmpAttackTime(double seconds) {
         this.ampAttackTime = Math.max(0.0, seconds);
-        this.ampEnvDirty = true;
+        this.ampEnvDirty.set(true);
     }
 
     public void setAmpDecayTime(double seconds) {
         this.ampDecayTime = Math.max(0.0, seconds);
-        this.ampEnvDirty = true;
+        this.ampEnvDirty.set(true);
     }
 
     public void setAmpSustainLevel(double level) {
         this.ampSustainLevel = Math.max(0.0, Math.min(1.0, level));
-        this.ampEnvDirty = true;
+        this.ampEnvDirty.set(true);
     }
 
     public void setAmpReleaseTime(double seconds) {
         this.ampReleaseTime = Math.max(0.0, seconds);
-        this.ampEnvDirty = true;
+        this.ampEnvDirty.set(true);
     }
 
     public void setPreFilterGainDB(double db) {
         this.preFilterGainDB = db;
-        this.gainDirty = true;
+        this.gainDirty.set(true);
     }
 
     public void setPostFilterGainDB(double db) {
         this.postFilterGainDB = db;
-        this.gainDirty = true;
+        this.gainDirty.set(true);
     }
 
     public void setLFOFrequency(double frequency) {
@@ -236,7 +240,7 @@ public class Synthesiser{
 
     public void setPanDepth(double depth) {
         this.panDepth = Math.max(0.0, Math.min(1.0, depth));
-        this.panDirty = true;
+        this.panDirty.set(true);
     }
 
     public void setMasterVolume(double volumeScalar){
@@ -446,13 +450,13 @@ public class Synthesiser{
 
         // Voice Processing and Mixing
         synchronized (voices) {
-            // Pull model: sync only dirty parameter groups to voices
-            boolean wf = this.waveformDirty;
-            boolean fi = this.filterDirty;
-            boolean fe = this.filterEnvDirty;
-            boolean ae = this.ampEnvDirty;
-            boolean ga = this.gainDirty;
-            boolean pa = this.panDirty;
+            // Pull model: sync only dirty parameter groups to voices (atomic read+clear)
+            boolean wf = this.waveformDirty.getAndSet(false);
+            boolean fi = this.filterDirty.getAndSet(false);
+            boolean fe = this.filterEnvDirty.getAndSet(false);
+            boolean ae = this.ampEnvDirty.getAndSet(false);
+            boolean ga = this.gainDirty.getAndSet(false);
+            boolean pa = this.panDirty.getAndSet(false);
 
             if (wf || fi || fe || ae || ga || pa) {
                 // Snapshot volatile fields into locals for consistent per-block updates
@@ -462,13 +466,6 @@ public class Synthesiser{
                 double aaSnap = this.ampAttackTime, adSnap = this.ampDecayTime, asSnap = this.ampSustainLevel, arSnap = this.ampReleaseTime;
                 double pfgSnap = this.preFilterGainDB, pfgPostSnap = this.postFilterGainDB;
                 double pdSnap = this.panDepth;
-
-                if (wf) this.waveformDirty = false;
-                if (fi) this.filterDirty = false;
-                if (fe) this.filterEnvDirty = false;
-                if (ae) this.ampEnvDirty = false;
-                if (ga) this.gainDirty = false;
-                if (pa) this.panDirty = false;
 
                 for (int i = 0; i < voices.length; i++) {
                     if (wf) voices[i].setOscillatorWaveform(wfSnap);
@@ -536,13 +533,13 @@ public class Synthesiser{
         // Voice Processing and Mixing
         startTime = System.nanoTime();
         synchronized (voices) {
-            // Pull model: sync only dirty parameter groups to voices
-            boolean wf = this.waveformDirty;
-            boolean fi = this.filterDirty;
-            boolean fe = this.filterEnvDirty;
-            boolean ae = this.ampEnvDirty;
-            boolean ga = this.gainDirty;
-            boolean pa = this.panDirty;
+            // Pull model: sync only dirty parameter groups to voices (atomic read+clear)
+            boolean wf = this.waveformDirty.getAndSet(false);
+            boolean fi = this.filterDirty.getAndSet(false);
+            boolean fe = this.filterEnvDirty.getAndSet(false);
+            boolean ae = this.ampEnvDirty.getAndSet(false);
+            boolean ga = this.gainDirty.getAndSet(false);
+            boolean pa = this.panDirty.getAndSet(false);
 
             if (wf || fi || fe || ae || ga || pa) {
                 // Snapshot volatile fields into locals for consistent per-block updates
@@ -552,13 +549,6 @@ public class Synthesiser{
                 double aaSnap = this.ampAttackTime, adSnap = this.ampDecayTime, asSnap = this.ampSustainLevel, arSnap = this.ampReleaseTime;
                 double pfgSnap = this.preFilterGainDB, pfgPostSnap = this.postFilterGainDB;
                 double pdSnap = this.panDepth;
-
-                if (wf) this.waveformDirty = false;
-                if (fi) this.filterDirty = false;
-                if (fe) this.filterEnvDirty = false;
-                if (ae) this.ampEnvDirty = false;
-                if (ga) this.gainDirty = false;
-                if (pa) this.panDirty = false;
 
                 for (int i = 0; i < voices.length; i++) {
                     if (wf) voices[i].setOscillatorWaveform(wfSnap);

--- a/src/main/java/synth/core/Synthesiser.java
+++ b/src/main/java/synth/core/Synthesiser.java
@@ -51,7 +51,7 @@ public class Synthesiser{
     private final Oscillator squareLFO;
     private volatile Waveform LFOWaveForm;
     private volatile double LFOFrequency;
-    private double LFOPosition;
+    private volatile double LFOPosition;
 
     // Panning
     private volatile double panDepth;

--- a/src/main/java/synth/core/Synthesiser.java
+++ b/src/main/java/synth/core/Synthesiser.java
@@ -12,6 +12,7 @@ import java.util.Map;
 public class Synthesiser{
     // Control all the voices. Bundles them up in an arraylist ready to be shipped to the buffer.
     private final Voice[] voices;
+    private final double sampleRate;
 
     // Master Configs (synth-wide settings)
     // Oscillator
@@ -42,6 +43,7 @@ public class Synthesiser{
     private volatile double postFilterGainDB;
     private final double voiceSumAttenuation;
     private volatile double volumeAttenuation;
+    private volatile double masterVolumeScalar = 1.0;
 
     // LFO
     private Oscillator LFO;
@@ -77,6 +79,7 @@ public class Synthesiser{
         if (noVoices <= 0) {
             throw new IllegalArgumentException("Number of voices must be positive.");
         }
+        this.sampleRate = sampleRate;
         this.voiceSumAttenuation = 1.0 / Math.sqrt(noVoices);
         this.volumeAttenuation = this.voiceSumAttenuation;
         this.voices = new Voice[noVoices];
@@ -132,6 +135,9 @@ public class Synthesiser{
      * @param LFOWaveForm The new waveform for the LFO.
      */
     public void setLFOWaveform(Waveform LFOWaveForm){
+        if (LFOWaveForm == null) {
+            throw new IllegalArgumentException("LFOWaveForm cannot be null");
+        }
         if(this.LFOWaveForm != LFOWaveForm){
             this.LFOWaveForm = LFOWaveForm;
         }
@@ -159,7 +165,8 @@ public class Synthesiser{
     }
 
     public void setFilterCutoff(double cutoff) {
-        this.filterCutoff = Math.max(20.0, Math.min(20000.0, cutoff)); // Clamp to audible range
+        double maxCutoff = (this.sampleRate / 2.0) - 1.0;
+        this.filterCutoff = Math.max(20.0, Math.min(maxCutoff, cutoff));
         this.filterDirty = true;
     }
 
@@ -233,6 +240,7 @@ public class Synthesiser{
     }
 
     public void setMasterVolume(double volumeScalar){
+        this.masterVolumeScalar = volumeScalar;
         this.volumeAttenuation = this.voiceSumAttenuation * volumeScalar;
     }
 
@@ -266,6 +274,7 @@ public class Synthesiser{
     public Waveform getLFOWaveform() { return LFOWaveForm; }
     public double getLFOFrequency() { return LFOFrequency; }
     public double getPanDepth() { return panDepth; }
+    public double getMasterVolumeScalar() { return masterVolumeScalar; }
 
     /**
      * Fills the provided array with active notes.
@@ -446,6 +455,14 @@ public class Synthesiser{
             boolean pa = this.panDirty;
 
             if (wf || fi || fe || ae || ga || pa) {
+                // Snapshot volatile fields into locals for consistent per-block updates
+                Waveform wfSnap = wf ? this.waveform : null;
+                double fcSnap = this.filterCutoff, frSnap = this.filterResonance, fmrSnap = this.filterModRange;
+                double faSnap = this.filterAttackTime, fdSnap = this.filterDecayTime, fsSnap = this.filterSustainLevel, frTSnap = this.filterReleaseTime;
+                double aaSnap = this.ampAttackTime, adSnap = this.ampDecayTime, asSnap = this.ampSustainLevel, arSnap = this.ampReleaseTime;
+                double pfgSnap = this.preFilterGainDB, pfgPostSnap = this.postFilterGainDB;
+                double pdSnap = this.panDepth;
+
                 if (wf) this.waveformDirty = false;
                 if (fi) this.filterDirty = false;
                 if (fe) this.filterEnvDirty = false;
@@ -454,12 +471,12 @@ public class Synthesiser{
                 if (pa) this.panDirty = false;
 
                 for (int i = 0; i < voices.length; i++) {
-                    if (wf) voices[i].setOscillatorWaveform(this.waveform);
-                    if (fi) voices[i].setFilterParameters(this.filterCutoff, this.filterResonance, this.filterModRange);
-                    if (fe) voices[i].setFilterEnvelope(this.filterAttackTime, this.filterDecayTime, this.filterSustainLevel, this.filterReleaseTime);
-                    if (ae) voices[i].setAmpEnvelope(this.ampAttackTime, this.ampDecayTime, this.ampSustainLevel, this.ampReleaseTime);
-                    if (ga) voices[i].setFilterGainStaging(this.preFilterGainDB, this.postFilterGainDB);
-                    if (pa) voices[i].setPanDepth(this.panDepth);
+                    if (wf) voices[i].setOscillatorWaveform(wfSnap);
+                    if (fi) voices[i].setFilterParameters(fcSnap, frSnap, fmrSnap);
+                    if (fe) voices[i].setFilterEnvelope(faSnap, fdSnap, fsSnap, frTSnap);
+                    if (ae) voices[i].setAmpEnvelope(aaSnap, adSnap, asSnap, arSnap);
+                    if (ga) voices[i].setFilterGainStaging(pfgSnap, pfgPostSnap);
+                    if (pa) voices[i].setPanDepth(pdSnap);
                 }
             }
 
@@ -470,11 +487,13 @@ public class Synthesiser{
                     voice.processBlock(null, this.voiceOutputBuffer, this.blockSize);
                     for(int j = 0; j < this.blockSize * 2; j++){
                         stereoOutputBuffer[j] += this.voiceOutputBuffer[j] * vol;
-                        this.LFOPosition = lfoOutputBuffer[j/2];
                     }
                 }
             }
         }
+
+        // Update LFO position once per block (last sample)
+        this.LFOPosition = lfoOutputBuffer[blockSize - 1];
 
         // Hard Clipping
         for (int i = 0; i < blockSize * 2; i++) {
@@ -526,6 +545,14 @@ public class Synthesiser{
             boolean pa = this.panDirty;
 
             if (wf || fi || fe || ae || ga || pa) {
+                // Snapshot volatile fields into locals for consistent per-block updates
+                Waveform wfSnap = wf ? this.waveform : null;
+                double fcSnap = this.filterCutoff, frSnap = this.filterResonance, fmrSnap = this.filterModRange;
+                double faSnap = this.filterAttackTime, fdSnap = this.filterDecayTime, fsSnap = this.filterSustainLevel, frTSnap = this.filterReleaseTime;
+                double aaSnap = this.ampAttackTime, adSnap = this.ampDecayTime, asSnap = this.ampSustainLevel, arSnap = this.ampReleaseTime;
+                double pfgSnap = this.preFilterGainDB, pfgPostSnap = this.postFilterGainDB;
+                double pdSnap = this.panDepth;
+
                 if (wf) this.waveformDirty = false;
                 if (fi) this.filterDirty = false;
                 if (fe) this.filterEnvDirty = false;
@@ -534,12 +561,12 @@ public class Synthesiser{
                 if (pa) this.panDirty = false;
 
                 for (int i = 0; i < voices.length; i++) {
-                    if (wf) voices[i].setOscillatorWaveform(this.waveform);
-                    if (fi) voices[i].setFilterParameters(this.filterCutoff, this.filterResonance, this.filterModRange);
-                    if (fe) voices[i].setFilterEnvelope(this.filterAttackTime, this.filterDecayTime, this.filterSustainLevel, this.filterReleaseTime);
-                    if (ae) voices[i].setAmpEnvelope(this.ampAttackTime, this.ampDecayTime, this.ampSustainLevel, this.ampReleaseTime);
-                    if (ga) voices[i].setFilterGainStaging(this.preFilterGainDB, this.postFilterGainDB);
-                    if (pa) voices[i].setPanDepth(this.panDepth);
+                    if (wf) voices[i].setOscillatorWaveform(wfSnap);
+                    if (fi) voices[i].setFilterParameters(fcSnap, frSnap, fmrSnap);
+                    if (fe) voices[i].setFilterEnvelope(faSnap, fdSnap, fsSnap, frTSnap);
+                    if (ae) voices[i].setAmpEnvelope(aaSnap, adSnap, asSnap, arSnap);
+                    if (ga) voices[i].setFilterGainStaging(pfgSnap, pfgPostSnap);
+                    if (pa) voices[i].setPanDepth(pdSnap);
                 }
             }
 
@@ -549,13 +576,15 @@ public class Synthesiser{
                     voice.processBlockInstrumented(this.lfoOutputBuffer, this.voiceOutputBuffer, this.blockSize, timings);
                     for(int j = 0; j < this.blockSize * 2; j++){
                         stereoOutputBuffer[j] += this.voiceOutputBuffer[j] * vol;
-                        this.LFOPosition = lfoOutputBuffer[j/2];
                     }
                 }
             }
         }
         endTime = System.nanoTime();
         timings.merge("Voice Processing & Mix", endTime - startTime, Long::sum);
+
+        // Update LFO position once per block (last sample)
+        this.LFOPosition = lfoOutputBuffer[blockSize - 1];
 
 
         // Hard Clipping

--- a/src/main/java/synth/core/Synthesiser.java
+++ b/src/main/java/synth/core/Synthesiser.java
@@ -18,30 +18,30 @@ public class Synthesiser{
     public enum Waveform {
         SINE, SAW, TRIANGLE, SQUARE
     }
-    private Waveform waveform;
+    private volatile Waveform waveform;
 
     // Filter
-    private double filterCutoff;
-    private double filterResonance;
-    private double filterModRange;
+    private volatile double filterCutoff;
+    private volatile double filterResonance;
+    private volatile double filterModRange;
 
     // Filter Envelope
-    private double filterAttackTime;
-    private double filterDecayTime;
-    private double filterSustainLevel;
-    private double filterReleaseTime;
+    private volatile double filterAttackTime;
+    private volatile double filterDecayTime;
+    private volatile double filterSustainLevel;
+    private volatile double filterReleaseTime;
 
     // Amp Envelope
-    private double ampAttackTime;
-    private double ampDecayTime;
-    private double ampSustainLevel;
-    private double ampReleaseTime;
+    private volatile double ampAttackTime;
+    private volatile double ampDecayTime;
+    private volatile double ampSustainLevel;
+    private volatile double ampReleaseTime;
 
     // Gain Staging
-    private double preFilterGainDB;
-    private double postFilterGainDB;
+    private volatile double preFilterGainDB;
+    private volatile double postFilterGainDB;
     private final double voiceSumAttenuation;
-    private double volumeAttenuation;
+    private volatile double volumeAttenuation;
 
     // LFO
     private Oscillator LFO;
@@ -49,12 +49,15 @@ public class Synthesiser{
     private final Oscillator sawLFO;
     private final Oscillator triangleLFO;
     private final Oscillator squareLFO;
-    private Waveform LFOWaveForm;
-    private double LFOFrequency;
+    private volatile Waveform LFOWaveForm;
+    private volatile double LFOFrequency;
     private double LFOPosition;
 
     // Panning
-    private double panDepth;
+    private volatile double panDepth;
+
+    // Dirty flag: setters set true, audio thread clears after syncing to voices
+    private volatile boolean paramsDirty = false;
 
     // Output Buffers
     int blockSize;
@@ -93,6 +96,7 @@ public class Synthesiser{
         this.sawLFO = new SawOscillator(sampleRate);
         this.triangleLFO = new TriangleOscillator(sampleRate);
         this.squareLFO = new SquareOscillator(sampleRate);
+        this.LFO = this.sineLFO;
 
         // Default Synth Patch
         loadPatch( // Applies default patch and populates the voice bank
@@ -125,15 +129,6 @@ public class Synthesiser{
     public void setLFOWaveform(Waveform LFOWaveForm){
         if(this.LFOWaveForm != LFOWaveForm){
             this.LFOWaveForm = LFOWaveForm;
-            // Switch to the pre-allocated oscillator
-            switch (LFOWaveForm){
-                case SINE -> this.LFO = this.sineLFO;
-                case SAW -> this.LFO = this.sawLFO;
-                case TRIANGLE -> this.LFO = this.triangleLFO;
-                case SQUARE -> this.LFO = this.squareLFO;
-                default -> throw new IllegalArgumentException("Unsupported waveform: " + LFOWaveForm);
-            }
-            this.LFO.setFrequency(this.LFOFrequency);
         }
     }
 
@@ -145,13 +140,12 @@ public class Synthesiser{
     public void setOscillatorWaveform(Waveform waveform){
         if (this.waveform != waveform){
             this.waveform = waveform;
-            for (int i = 0; i < voices.length; i++){
-                voices[i].setOscillatorWaveform(waveform);
-            }
+            this.paramsDirty = true;
         }
     }
 
     public void setVoiceParams(Voice voice){
+        voice.setOscillatorWaveform(this.waveform);
         voice.setAmpEnvelope(this.ampAttackTime, this.ampDecayTime, this.ampSustainLevel, this.ampReleaseTime);
         voice.setFilterEnvelope(this.filterAttackTime, this.filterDecayTime, this.filterSustainLevel, this.filterReleaseTime);
         voice.setFilterParameters(this.filterCutoff, this.filterResonance, this.filterModRange);
@@ -161,102 +155,76 @@ public class Synthesiser{
 
     public void setFilterCutoff(double cutoff) {
         this.filterCutoff = Math.max(20.0, Math.min(20000.0, cutoff)); // Clamp to audible range
-        for (int i = 0; i < voices.length; i++) {
-            voices[i].setFilterParameters(this.filterCutoff, this.filterResonance, this.filterModRange);
-        }
+        this.paramsDirty = true;
     }
 
     public void setFilterResonance(double resonance) {
         this.filterResonance = Math.max(1.0, Math.min(20.0, resonance)); // Clamp from 1 to 20
-        for (int i = 0; i < voices.length; i++) {
-            voices[i].setFilterParameters(this.filterCutoff, this.filterResonance, this.filterModRange);
-        }
+        this.paramsDirty = true;
     }
 
     public void setFilterModRange(double modRange) {
         this.filterModRange = Math.max(0.0, modRange);
-        for (int i = 0; i < voices.length; i++) {
-            voices[i].setFilterParameters(this.filterCutoff, this.filterResonance, this.filterModRange);
-        }
+        this.paramsDirty = true;
     }
 
     public void setFilterAttackTime(double seconds) {
         this.filterAttackTime = Math.max(0.0, seconds);
-        for (int i = 0; i < voices.length; i++) {
-            voices[i].setFilterEnvelopeAttackTime(this.filterAttackTime);
-        }
+        this.paramsDirty = true;
     }
 
     public void setFilterDecayTime(double seconds) {
         this.filterDecayTime = Math.max(0.0, seconds);
-        for (int i = 0; i < voices.length; i++) {
-            voices[i].setFilterEnvelopeDecayTime(this.filterDecayTime);
-        }
+        this.paramsDirty = true;
     }
 
     public void setFilterSustainLevel(double level) {
         this.filterSustainLevel = Math.max(0.0, Math.min(1.0, level));
-        for (int i = 0; i < voices.length; i++) {
-            voices[i].setFilterEnvelopeSustainLevel(this.filterSustainLevel);
-        }
+        this.paramsDirty = true;
     }
 
     public void setFilterReleaseTime(double seconds) {
         this.filterReleaseTime = Math.max(0.0, seconds);
-        for (int i = 0; i < voices.length; i++) {
-            voices[i].setFilterEnvelopeReleaseTime(this.filterReleaseTime);
-        }
+        this.paramsDirty = true;
     }
 
     public void setAmpAttackTime(double seconds) {
         this.ampAttackTime = Math.max(0.0, seconds);
-        for (int i = 0; i < voices.length; i++) {
-            voices[i].setAmpEnvelopeAttackTime(this.ampAttackTime);
-        }
+        this.paramsDirty = true;
     }
 
     public void setAmpDecayTime(double seconds) {
         this.ampDecayTime = Math.max(0.0, seconds);
-        for (int i = 0; i < voices.length; i++) {
-            voices[i].setAmpEnvelopeDecayTime(this.ampDecayTime);
-        }
+        this.paramsDirty = true;
     }
 
     public void setAmpSustainLevel(double level) {
         this.ampSustainLevel = Math.max(0.0, Math.min(1.0, level));
-        for (int i = 0; i < voices.length; i++) {
-            voices[i].setAmpEnvelopeSustainLevel(this.ampSustainLevel);
-        }
+        this.paramsDirty = true;
     }
 
     public void setAmpReleaseTime(double seconds) {
         this.ampReleaseTime = Math.max(0.0, seconds);
-        for (int i = 0; i < voices.length; i++) {
-            voices[i].setAmpEnvelopeReleaseTime(this.ampReleaseTime);
-        }
+        this.paramsDirty = true;
     }
 
     public void setPreFilterGainDB(double db) {
         this.preFilterGainDB = db;
-        for (int i = 0; i < voices.length; i++) {
-            voices[i].setFilterGainStaging(this.preFilterGainDB, this.postFilterGainDB);
-        }
+        this.paramsDirty = true;
     }
 
     public void setPostFilterGainDB(double db) {
         this.postFilterGainDB = db;
-        for (int i = 0; i < voices.length; i++) {
-            voices[i].setFilterGainStaging(this.preFilterGainDB, this.postFilterGainDB);
-        }
+        this.paramsDirty = true;
     }
 
     public void setLFOFrequency(double frequency) {
         this.LFOFrequency = Math.max(0.0, frequency);
-        this.LFO.setFrequency(this.LFOFrequency);
     }
 
     public void setPanDepth(double depth) {
         this.panDepth = Math.max(0.0, Math.min(1.0, depth));
+        this.paramsDirty = true;
     }
 
     public void setMasterVolume(double volumeScalar){
@@ -448,18 +416,37 @@ public class Synthesiser{
         // Clear the output buffer
         Arrays.fill(stereoOutputBuffer, 0.0);
 
+        // Sync LFO settings from volatile fields (audio thread is sole consumer of LFO object)
+        switch (this.LFOWaveForm) {
+            case SINE -> this.LFO = this.sineLFO;
+            case SAW -> this.LFO = this.sawLFO;
+            case TRIANGLE -> this.LFO = this.triangleLFO;
+            case SQUARE -> this.LFO = this.squareLFO;
+        }
+        this.LFO.setFrequency(this.LFOFrequency);
+
         // Populate LFO buffer
         LFO.processBlock(null, this.lfoOutputBuffer, blockSize);
 
+        double vol = this.volumeAttenuation;
+
         // Voice Processing and Mixing
         synchronized (voices) {
+            // Pull model: sync parameters to voices when any setter has fired
+            if (this.paramsDirty) {
+                this.paramsDirty = false;
+                for (int i = 0; i < voices.length; i++) {
+                    setVoiceParams(voices[i]);
+                }
+            }
+
             for (int i = 0; i < voices.length; i++) {
                 Voice voice = voices[i];
                 if (voice.isActive()) {
                     // If the voice is active, process its block and sum it into the output buffer.
                     voice.processBlock(null, this.voiceOutputBuffer, this.blockSize);
                     for(int j = 0; j < this.blockSize * 2; j++){
-                        stereoOutputBuffer[j] += this.voiceOutputBuffer[j] * this.volumeAttenuation;
+                        stereoOutputBuffer[j] += this.voiceOutputBuffer[j] * vol;
                         this.LFOPosition = lfoOutputBuffer[j/2];
                     }
                 }
@@ -487,21 +474,40 @@ public class Synthesiser{
         timings.clear();
         Arrays.fill(stereoOutputBuffer, 0.0);
 
+        // Sync LFO settings from volatile fields (audio thread is sole consumer of LFO object)
+        switch (this.LFOWaveForm) {
+            case SINE -> this.LFO = this.sineLFO;
+            case SAW -> this.LFO = this.sawLFO;
+            case TRIANGLE -> this.LFO = this.triangleLFO;
+            case SQUARE -> this.LFO = this.squareLFO;
+        }
+        this.LFO.setFrequency(this.LFOFrequency);
+
         // Populate LFO buffer
         startTime = System.nanoTime();
         LFO.processBlock(null, this.lfoOutputBuffer, blockSize);
         endTime = System.nanoTime();
         timings.merge("LFO", endTime - startTime, Long::sum);
 
+        double vol = this.volumeAttenuation;
+
         // Voice Processing and Mixing
         startTime = System.nanoTime();
         synchronized (voices) {
+            // Pull model: sync parameters to voices when any setter has fired
+            if (this.paramsDirty) {
+                this.paramsDirty = false;
+                for (int i = 0; i < voices.length; i++) {
+                    setVoiceParams(voices[i]);
+                }
+            }
+
             for (int i = 0; i < voices.length; i++) {
                 Voice voice = voices[i];
                 if (voice.isActive()) {
                     voice.processBlockInstrumented(this.lfoOutputBuffer, this.voiceOutputBuffer, this.blockSize, timings);
                     for(int j = 0; j < this.blockSize * 2; j++){
-                        stereoOutputBuffer[j] += this.voiceOutputBuffer[j] * this.volumeAttenuation;
+                        stereoOutputBuffer[j] += this.voiceOutputBuffer[j] * vol;
                         this.LFOPosition = lfoOutputBuffer[j/2];
                     }
                 }

--- a/src/main/java/synth/core/Synthesiser.java
+++ b/src/main/java/synth/core/Synthesiser.java
@@ -150,8 +150,8 @@ public class Synthesiser{
     }
 
     /**
-     * Updates the main oscillator waveform for all voices.
-     * This will clear and repopulate the voice bank with new oscillators.
+     * Sets the main oscillator waveform. The change is deferred and applied
+     * to all voices by the audio thread at the start of the next processing block.
      * @param waveform The new waveform to use.
      */
     public void setOscillatorWaveform(Waveform waveform){
@@ -258,12 +258,14 @@ public class Synthesiser{
      * Applies all current patch settings to all voices. Hook for potential future patch loading system.
      */
     public void applyPatch(){
-        setOscillatorWaveform(this.waveform);
-        setLFOWaveform(this.LFOWaveForm);
-        for(int i = 0; i < voices.length; i++){
-            setVoiceParams(voices[i]);
+        synchronized (voices) {
+            setOscillatorWaveform(this.waveform);
+            setLFOWaveform(this.LFOWaveForm);
+            for(int i = 0; i < voices.length; i++){
+                setVoiceParams(voices[i]);
+            }
+            setLFOFrequency(this.LFOFrequency);
         }
-        setLFOFrequency(this.LFOFrequency);
     }
 
     //  --- Getters ---

--- a/src/main/java/synth/midi/MidiDeviceConnector.java
+++ b/src/main/java/synth/midi/MidiDeviceConnector.java
@@ -80,6 +80,17 @@ public class MidiDeviceConnector {
      * @return The MidiDevice object if connection is successful, otherwise null.
      */
     public static MidiDevice connectToDevice(Synthesiser synth, String deviceName) {
+        return connectToDevice(synth, deviceName, null);
+    }
+
+    /**
+     * Connects the synthesiser to the first MIDI input device found with the specified name.
+     * @param synth The Synthesiser instance to connect.
+     * @param deviceName The name of the MIDI device to connect to (e.g., "IAC Driver Bus 1").
+     * @param onControlChange Optional callback invoked after a MIDI CC message is processed.
+     * @return The MidiDevice object if connection is successful, otherwise null.
+     */
+    public static MidiDevice connectToDevice(Synthesiser synth, String deviceName, Runnable onControlChange) {
         MidiDevice.Info[] infos = MidiSystem.getMidiDeviceInfo();
         for (MidiDevice.Info info : infos) {
             if (info.getName().equals(deviceName)) {
@@ -89,7 +100,7 @@ public class MidiDeviceConnector {
                     if (device.getMaxTransmitters() != 0) {
                         device.open();
                         Transmitter transmitter = device.getTransmitter();
-                        transmitter.setReceiver(new MidiInputHandler(synth));
+                        transmitter.setReceiver(new MidiInputHandler(synth, onControlChange));
                         System.out.println("Successfully connected to MIDI device: " + deviceName);
                         return device;
                     }

--- a/src/main/java/synth/midi/MidiDeviceConnector.java
+++ b/src/main/java/synth/midi/MidiDeviceConnector.java
@@ -19,12 +19,16 @@ public class MidiDeviceConnector {
      * An input device is one that can send MIDI messages (has at least one transmitter).
      */
     public static ArrayList<String> getMidiDevicesList() {
+        return getMidiDevicesList(false);
+    }
+
+    public static ArrayList<String> getMidiDevicesList(boolean verbose) {
         ArrayList<String> Devices = new ArrayList<>();
-        System.out.println("--- Select MIDI Input Device ---");
+        if (verbose) System.out.println("--- Select MIDI Input Device ---");
         MidiDevice.Info[] infos = MidiSystem.getMidiDeviceInfo();
         if (infos.length == 0) {
-            System.out.println("No MIDI devices found.");
-            return null;
+            if (verbose) System.out.println("No MIDI devices found.");
+            return Devices;
         }
         int i = 1;
         for (MidiDevice.Info info : infos) {
@@ -32,13 +36,13 @@ public class MidiDeviceConnector {
                 MidiDevice device = MidiSystem.getMidiDevice(info);
                 if (device.getMaxTransmitters() != 0) {
                     Devices.add(info.getName());
-                    System.out.println(i + "- " + info.getName());
+                    if (verbose) System.out.println(i + "- " + info.getName());
                     i ++;
                 }
             } catch (MidiUnavailableException e) {
             }
         }
-        System.out.println("------------------------------------");
+        if (verbose) System.out.println("------------------------------------");
         return Devices;
     }
 
@@ -48,7 +52,7 @@ public class MidiDeviceConnector {
      * @return The name of the selected MIDI device, or null if none are found.
      */
     public static String promptUser() {
-        ArrayList<String> devices = getMidiDevicesList();
+        ArrayList<String> devices = getMidiDevicesList(true);
         if (devices == null || devices.isEmpty()) {
             System.out.println("No MIDI devices available.");
             return null;

--- a/src/main/java/synth/midi/MidiDeviceConnector.java
+++ b/src/main/java/synth/midi/MidiDeviceConnector.java
@@ -23,19 +23,19 @@ public class MidiDeviceConnector {
     }
 
     public static ArrayList<String> getMidiDevicesList(boolean verbose) {
-        ArrayList<String> Devices = new ArrayList<>();
+        ArrayList<String> devices = new ArrayList<>();
         if (verbose) System.out.println("--- Select MIDI Input Device ---");
         MidiDevice.Info[] infos = MidiSystem.getMidiDeviceInfo();
         if (infos.length == 0) {
             if (verbose) System.out.println("No MIDI devices found.");
-            return Devices;
+            return devices;
         }
         int i = 1;
         for (MidiDevice.Info info : infos) {
             try {
                 MidiDevice device = MidiSystem.getMidiDevice(info);
                 if (device.getMaxTransmitters() != 0) {
-                    Devices.add(info.getName());
+                    devices.add(info.getName());
                     if (verbose) System.out.println(i + "- " + info.getName());
                     i ++;
                 }
@@ -43,7 +43,7 @@ public class MidiDeviceConnector {
             }
         }
         if (verbose) System.out.println("------------------------------------");
-        return Devices;
+        return devices;
     }
 
     /**

--- a/src/main/java/synth/midi/MidiDeviceConnector.java
+++ b/src/main/java/synth/midi/MidiDeviceConnector.java
@@ -1,10 +1,15 @@
 package synth.midi;
 
-import synth.core.Synthesiser;
-import javax.sound.midi.*;
 import java.util.ArrayList;
-import java.util.Scanner;
 import java.util.InputMismatchException;
+import java.util.Scanner;
+
+import javax.sound.midi.MidiDevice;
+import javax.sound.midi.MidiSystem;
+import javax.sound.midi.MidiUnavailableException;
+import javax.sound.midi.Transmitter;
+
+import synth.core.Synthesiser;
 
 
 public class MidiDeviceConnector {

--- a/src/main/java/synth/midi/MidiDeviceConnector.java
+++ b/src/main/java/synth/midi/MidiDeviceConnector.java
@@ -53,7 +53,7 @@ public class MidiDeviceConnector {
      */
     public static String promptUser() {
         ArrayList<String> devices = getMidiDevicesList(true);
-        if (devices == null || devices.isEmpty()) {
+        if (devices.isEmpty()) {
             System.out.println("No MIDI devices available.");
             return null;
         }

--- a/src/main/java/synth/midi/MidiDeviceConnector.java
+++ b/src/main/java/synth/midi/MidiDeviceConnector.java
@@ -41,6 +41,9 @@ public class MidiDeviceConnector {
                     i ++;
                 }
             } catch (MidiUnavailableException e) {
+                if (verbose) {
+                    System.err.println("Skipping MIDI device '" + info.getName() + "': " + e.getMessage());
+                }
             }
         }
         if (verbose) System.out.println("------------------------------------");

--- a/src/main/java/synth/midi/MidiDeviceConnector.java
+++ b/src/main/java/synth/midi/MidiDeviceConnector.java
@@ -15,8 +15,9 @@ import synth.core.Synthesiser;
 public class MidiDeviceConnector {
 
     /**
-     * Lists all available MIDI input devices to the console.
+     * Returns all available MIDI input device names.
      * An input device is one that can send MIDI messages (has at least one transmitter).
+     * Equivalent to {@code getMidiDevicesList(false)} (no console output).
      */
     public static ArrayList<String> getMidiDevicesList() {
         return getMidiDevicesList(false);

--- a/src/main/java/synth/midi/MidiInputHandler.java
+++ b/src/main/java/synth/midi/MidiInputHandler.java
@@ -156,7 +156,11 @@ public class MidiInputHandler implements Receiver{
                 }
 
                 if (handled && onControlChange != null) {
-                    onControlChange.run();
+                    try {
+                        onControlChange.run();
+                    } catch (Exception e) {
+                        System.err.println("Error in MIDI CC callback: " + e.getMessage());
+                    }
                 }
             }
         }

--- a/src/main/java/synth/midi/MidiInputHandler.java
+++ b/src/main/java/synth/midi/MidiInputHandler.java
@@ -11,16 +11,27 @@ import synth.core.Synthesiser;
  */
 public class MidiInputHandler implements Receiver{
     private final Synthesiser synth;
+    private final Runnable onControlChange;
 
     /**
      * Constructs a MidiInputHandler.
      * @param synth The synthesiser to be controlled. Must not be null.
      */
     public MidiInputHandler(Synthesiser synth) {
+        this(synth, null);
+    }
+
+    /**
+     * Constructs a MidiInputHandler with a control change callback.
+     * @param synth The synthesiser to be controlled. Must not be null.
+     * @param onControlChange Optional callback invoked after a CC message is processed.
+     */
+    public MidiInputHandler(Synthesiser synth, Runnable onControlChange) {
         if (synth == null) {
             throw new IllegalArgumentException("Synthesiser cannot be null.");
         }
         this.synth = synth;
+        this.onControlChange = onControlChange;
     }
 
     /**
@@ -132,11 +143,15 @@ public class MidiInputHandler implements Receiver{
                         break;
                     case 15: // Post-Filter Gain)
                         // Ranges 24dB to +24dB
-                        synth.setPreFilterGainDB((scaledValue * 48.0) - 24.0);
+                        synth.setPostFilterGainDB((scaledValue * 48.0) - 24.0);
                         break;
                     case 16: // Pan Depth
                         synth.setPanDepth(scaledValue);
                         break;
+                }
+
+                if (onControlChange != null) {
+                    onControlChange.run();
                 }
             }
         }

--- a/src/main/java/synth/midi/MidiInputHandler.java
+++ b/src/main/java/synth/midi/MidiInputHandler.java
@@ -62,6 +62,7 @@ public class MidiInputHandler implements Receiver{
                 double scaledValue = value / 127.0;
 
                 // Parameter control switch:
+                boolean handled = true;
                 switch (controller) {
                     // --- OSCILLATOR CONTROLS ---
                     case 32: // Modulation Wheel, LFO Frequency
@@ -149,9 +150,12 @@ public class MidiInputHandler implements Receiver{
                     case 16: // Pan Depth
                         synth.setPanDepth(scaledValue);
                         break;
+                    default:
+                        handled = false;
+                        break;
                 }
 
-                if (onControlChange != null) {
+                if (handled && onControlChange != null) {
                     onControlChange.run();
                 }
             }

--- a/src/main/java/synth/midi/MidiInputHandler.java
+++ b/src/main/java/synth/midi/MidiInputHandler.java
@@ -3,6 +3,7 @@ package synth.midi;
 import javax.sound.midi.MidiMessage;
 import javax.sound.midi.Receiver;
 import javax.sound.midi.ShortMessage;
+
 import synth.core.Synthesiser;
 
 /**

--- a/src/main/java/synth/tests/PerformanceTest.java
+++ b/src/main/java/synth/tests/PerformanceTest.java
@@ -1,12 +1,12 @@
 package synth.tests;
 
-import synth.core.Synthesiser;
-import synth.utils.AudioConstants;
-
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import synth.core.Synthesiser;
+import synth.utils.AudioConstants;
 
 public class PerformanceTest {
 

--- a/src/main/java/synth/tests/PerformanceTest.java
+++ b/src/main/java/synth/tests/PerformanceTest.java
@@ -113,6 +113,16 @@ public class PerformanceTest {
         }
 
         running.set(false);
+        setterThread.interrupt();
+        try {
+            setterThread.join(TimeUnit.SECONDS.toMillis(2));
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            System.err.println("Interrupted while waiting for setter thread to stop.");
+        }
+        if (setterThread.isAlive()) {
+            System.err.println("Setter thread did not stop within the timeout.");
+        }
         System.out.println("Contention test complete.\n");
 
         // Print results

--- a/src/main/java/synth/tests/PerformanceTest.java
+++ b/src/main/java/synth/tests/PerformanceTest.java
@@ -6,10 +6,17 @@ import synth.utils.AudioConstants;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class PerformanceTest {
 
     public static void main(String[] args) {
+        runStandardTest();
+        System.out.println("\n");
+        runContentionStressTest();
+    }
+
+    private static void runStandardTest() {
         // Setup
         int numberOfBlocksToProcess = 2000;
         Synthesiser synth = new Synthesiser(
@@ -53,6 +60,71 @@ public class PerformanceTest {
                     String stage = entry.getKey();
                     long averageTime = timeInNanos / numberOfBlocksToProcess;
                     System.out.printf("%-25s: %d µs%n", stage, TimeUnit.NANOSECONDS.toMicros(averageTime));
+                });
+        System.out.println("------------------------------------------");
+    }
+
+    private static void runContentionStressTest() {
+        int numberOfBlocksToProcess = 2000;
+        Synthesiser synth = new Synthesiser(
+                AudioConstants.NUMBER_OF_VOICES,
+                AudioConstants.SAMPLE_RATE,
+                AudioConstants.BLOCK_SIZE);
+
+        double[] audioBlock = new double[AudioConstants.BLOCK_SIZE * 2];
+        Map<String, Long> totalTimings = new HashMap<>();
+
+        // Activate voices
+        System.out.println("=== Contention Stress Test ===");
+        System.out.println("Activating " + AudioConstants.NUMBER_OF_VOICES + " voices...");
+        for (int i = 0; i < AudioConstants.NUMBER_OF_VOICES; i++) {
+            synth.noteOn((byte) (60 + i), 1.0);
+        }
+
+        // Start a setter-spam thread simulating rapid MIDI CC messages
+        AtomicBoolean running = new AtomicBoolean(true);
+        Thread setterThread = new Thread(() -> {
+            double v = 0.0;
+            while (running.get()) {
+                v += 0.01;
+                if (v > 1.0) v = 0.0;
+                synth.setFilterCutoff(20.0 + v * 19980.0);
+                synth.setFilterResonance(1.0 + v * 14.0);
+                synth.setAmpAttackTime(v * 2.0);
+                synth.setAmpReleaseTime(v * 2.0);
+                synth.setPreFilterGainDB(v * 24.0 - 12.0);
+                synth.setMasterVolume(0.5 + v * 0.5);
+                synth.setLFOFrequency(0.1 + v * 9.9);
+                synth.setPanDepth(v);
+            }
+        });
+        setterThread.setDaemon(true);
+        setterThread.start();
+
+        // Run processing loop under contention
+        System.out.println("Processing " + numberOfBlocksToProcess + " blocks under contention...");
+        long totalTestTime = 0;
+        for (int i = 0; i < numberOfBlocksToProcess; i++) {
+            long blockStartTime = System.nanoTime();
+            Map<String, Long> blockTimings = synth.processBlockInstrumented(audioBlock);
+            long blockEndTime = System.nanoTime();
+            totalTestTime += (blockEndTime - blockStartTime);
+            blockTimings.forEach((key, value) -> totalTimings.merge(key, value, Long::sum));
+        }
+
+        running.set(false);
+        System.out.println("Contention test complete.\n");
+
+        // Print results
+        System.out.println("--- Contention Stress Test Results ---");
+        System.out.println("Total processing time: " + TimeUnit.NANOSECONDS.toMillis(totalTestTime) + " ms");
+        System.out.println("\n--- Average Time Per Stage (in microseconds) ---");
+        totalTimings.entrySet().stream()
+                .sorted(Map.Entry.<String, Long>comparingByValue().reversed())
+                .forEach(entry -> {
+                    long averageTime = entry.getValue() / numberOfBlocksToProcess;
+                    System.out.printf("%-25s: %d µs%n", entry.getKey(),
+                            TimeUnit.NANOSECONDS.toMicros(averageTime));
                 });
         System.out.println("------------------------------------------");
     }

--- a/src/main/java/synth/ui/SynthUIController.java
+++ b/src/main/java/synth/ui/SynthUIController.java
@@ -564,16 +564,18 @@ public class SynthUIController implements Initializable {
     /**
      * Called from the MIDI thread when a CC message is processed.
      * Schedules a coalesced UI sync on the JavaFX application thread.
+     * Clearing the pending flag at the start of execution allows CCs arriving
+     * during sync to schedule a fresh runLater, preventing stale UI state.
      */
     private void onMidiControlChange() {
         if (midiSyncPending.compareAndSet(false, true)) {
             Platform.runLater(() -> {
+                midiSyncPending.set(false);
                 syncingFromMidi = true;
                 try {
                     syncUIWithSynthSettings();
                 } finally {
                     syncingFromMidi = false;
-                    midiSyncPending.set(false);
                 }
             });
         }

--- a/src/main/java/synth/ui/SynthUIController.java
+++ b/src/main/java/synth/ui/SynthUIController.java
@@ -37,9 +37,9 @@ import synth.utils.AudioDeviceConnector;
 public class SynthUIController implements Initializable {
 
     private Synthesiser synth;
-    private SourceDataLine line;
+    private volatile SourceDataLine line;
     private MidiDevice midiDevice;
-    private Thread audioThread;
+    private volatile Thread audioThread;
     private volatile boolean audioThreadRunning = false;
     
     // Performance logging variables

--- a/src/main/java/synth/ui/SynthUIController.java
+++ b/src/main/java/synth/ui/SynthUIController.java
@@ -6,6 +6,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.ResourceBundle;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -14,14 +16,11 @@ import javax.sound.sampled.AudioFormat;
 import javax.sound.sampled.LineUnavailableException;
 import javax.sound.sampled.SourceDataLine;
 
-import javafx.animation.KeyFrame;
-import javafx.animation.Timeline;
 import javafx.application.Platform;
 import javafx.collections.FXCollections;
 import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
 import javafx.scene.control.ChoiceBox;
-import javafx.util.Duration;
 import javafx.scene.control.Label;
 import javafx.scene.control.Slider;
 import javafx.scene.layout.VBox;
@@ -114,7 +113,7 @@ public class SynthUIController implements Initializable {
     @FXML private Slider postFilterGainSlider;
     @FXML private Label postFilterGainLabel;
     
-    private Timeline deviceScanTimeline;
+    private ScheduledExecutorService deviceScanExecutor;
 
     // Flag to prevent redundant synth calls when syncing UI from MIDI CC
     private boolean syncingFromMidi = false;
@@ -138,9 +137,13 @@ public class SynthUIController implements Initializable {
         setupControls();
         syncUIWithSynthSettings();
 
-        deviceScanTimeline = new Timeline(new KeyFrame(Duration.seconds(AudioConstants.DEVICE_SCAN_INTERVAL_SECONDS), e -> refreshDeviceLists()));
-        deviceScanTimeline.setCycleCount(Timeline.INDEFINITE);
-        deviceScanTimeline.play();
+        deviceScanExecutor = Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = new Thread(r, "device-scan");
+            t.setDaemon(true);
+            return t;
+        });
+        long intervalMs = (long) (AudioConstants.DEVICE_SCAN_INTERVAL_SECONDS * 1000);
+        deviceScanExecutor.scheduleAtFixedRate(this::refreshDeviceLists, intervalMs, intervalMs, TimeUnit.MILLISECONDS);
     }
 
     /**
@@ -176,22 +179,25 @@ public class SynthUIController implements Initializable {
 
     private void refreshDeviceLists() {
         ArrayList<String> newMidi = MidiDeviceConnector.getMidiDevicesList();
-        if (!newMidi.equals(new ArrayList<>(midiDeviceChoiceBox.getItems()))) {
-            String selected = midiDeviceChoiceBox.getValue();
-            midiDeviceChoiceBox.setItems(FXCollections.observableArrayList(newMidi));
-            if (newMidi.contains(selected)) {
-                midiDeviceChoiceBox.setValue(selected);
-            }
-        }
-
         ArrayList<String> newAudio = AudioDeviceConnector.getAudioOutputDeviceList();
-        if (!newAudio.equals(new ArrayList<>(audioDeviceChoiceBox.getItems()))) {
-            String selected = audioDeviceChoiceBox.getValue();
-            audioDeviceChoiceBox.setItems(FXCollections.observableArrayList(newAudio));
-            if (newAudio.contains(selected)) {
-                audioDeviceChoiceBox.setValue(selected);
+
+        Platform.runLater(() -> {
+            if (!newMidi.equals(new ArrayList<>(midiDeviceChoiceBox.getItems()))) {
+                String selected = midiDeviceChoiceBox.getValue();
+                midiDeviceChoiceBox.setItems(FXCollections.observableArrayList(newMidi));
+                if (newMidi.contains(selected)) {
+                    midiDeviceChoiceBox.setValue(selected);
+                }
             }
-        }
+
+            if (!newAudio.equals(new ArrayList<>(audioDeviceChoiceBox.getItems()))) {
+                String selected = audioDeviceChoiceBox.getValue();
+                audioDeviceChoiceBox.setItems(FXCollections.observableArrayList(newAudio));
+                if (newAudio.contains(selected)) {
+                    audioDeviceChoiceBox.setValue(selected);
+                }
+            }
+        });
     }
 
     /**
@@ -653,8 +659,8 @@ public class SynthUIController implements Initializable {
      * Safely closes audio and MIDI resources when the application exits.
      */
     public void shutdown() {
-        if (deviceScanTimeline != null) {
-            deviceScanTimeline.stop();
+        if (deviceScanExecutor != null) {
+            deviceScanExecutor.shutdownNow();
         }
 
         // Stop the audio thread

--- a/src/main/java/synth/ui/SynthUIController.java
+++ b/src/main/java/synth/ui/SynthUIController.java
@@ -115,6 +115,9 @@ public class SynthUIController implements Initializable {
     
     private ScheduledExecutorService deviceScanExecutor;
 
+    // Guard to suppress device-change listeners during refresh
+    private boolean refreshingDevices = false;
+
     // Flag to prevent redundant synth calls when syncing UI from MIDI CC
     private boolean syncingFromMidi = false;
     // Coalescing flag for MIDI CC UI sync
@@ -159,7 +162,7 @@ public class SynthUIController implements Initializable {
         ArrayList<String> audioDevices = AudioDeviceConnector.getAudioOutputDeviceList(true);
         audioDeviceChoiceBox.setItems(FXCollections.observableArrayList(audioDevices));
         audioDeviceChoiceBox.getSelectionModel().selectedItemProperty().addListener((obs, oldDevice, newDevice) -> {
-            if (newDevice != null) {
+            if (newDevice != null && !refreshingDevices) {
                 changeAudioDevice(newDevice);
             }
         });
@@ -168,7 +171,7 @@ public class SynthUIController implements Initializable {
         ArrayList<String> midiDevices = MidiDeviceConnector.getMidiDevicesList(true);
         midiDeviceChoiceBox.setItems(FXCollections.observableArrayList(midiDevices));
         midiDeviceChoiceBox.getSelectionModel().selectedItemProperty().addListener((obs, oldDevice, newDevice) -> {
-            if (newDevice != null) {
+            if (newDevice != null && !refreshingDevices) {
                 changeMidiDevice(newDevice);
             }
         });
@@ -187,20 +190,25 @@ public class SynthUIController implements Initializable {
         ArrayList<String> newAudio = AudioDeviceConnector.getAudioOutputDeviceList();
 
         Platform.runLater(() -> {
-            if (!newMidi.equals(new ArrayList<>(midiDeviceChoiceBox.getItems()))) {
-                String selected = midiDeviceChoiceBox.getValue();
-                midiDeviceChoiceBox.getItems().setAll(newMidi);
-                if (newMidi.contains(selected)) {
-                    midiDeviceChoiceBox.setValue(selected);
+            refreshingDevices = true;
+            try {
+                if (!newMidi.equals(new ArrayList<>(midiDeviceChoiceBox.getItems()))) {
+                    String selected = midiDeviceChoiceBox.getValue();
+                    midiDeviceChoiceBox.getItems().setAll(newMidi);
+                    if (newMidi.contains(selected)) {
+                        midiDeviceChoiceBox.setValue(selected);
+                    }
                 }
-            }
 
-            if (!newAudio.equals(new ArrayList<>(audioDeviceChoiceBox.getItems()))) {
-                String selected = audioDeviceChoiceBox.getValue();
-                audioDeviceChoiceBox.getItems().setAll(newAudio);
-                if (newAudio.contains(selected)) {
-                    audioDeviceChoiceBox.setValue(selected);
+                if (!newAudio.equals(new ArrayList<>(audioDeviceChoiceBox.getItems()))) {
+                    String selected = audioDeviceChoiceBox.getValue();
+                    audioDeviceChoiceBox.getItems().setAll(newAudio);
+                    if (newAudio.contains(selected)) {
+                        audioDeviceChoiceBox.setValue(selected);
+                    }
                 }
+            } finally {
+                refreshingDevices = false;
             }
         });
     }

--- a/src/main/java/synth/ui/SynthUIController.java
+++ b/src/main/java/synth/ui/SynthUIController.java
@@ -465,7 +465,8 @@ public class SynthUIController implements Initializable {
         filterEnvelopeVisualizer.setReleaseTime(synth.getFilterReleaseTime());
         
         // Global Control settings
-        masterVolumeSlider.setValue(currentMasterVolume);
+        masterVolumeSlider.setValue(synth.getMasterVolumeScalar());
+        currentMasterVolume = synth.getMasterVolumeScalar();
         panDepthSlider.setValue(synth.getPanDepth());
         preFilterGainSlider.setValue(synth.getPreFilterGainDB());
         postFilterGainSlider.setValue(synth.getPostFilterGainDB());

--- a/src/main/java/synth/ui/SynthUIController.java
+++ b/src/main/java/synth/ui/SynthUIController.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.ResourceBundle;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.sound.midi.MidiDevice;
 import javax.sound.sampled.AudioFormat;
@@ -112,6 +113,11 @@ public class SynthUIController implements Initializable {
     
     // Track master volume since synth doesn't have a getter
     private double currentMasterVolume = 1.0;
+    
+    // Flag to prevent redundant synth calls when syncing UI from MIDI CC
+    private boolean syncingFromMidi = false;
+    // Coalescing flag for MIDI CC UI sync
+    private final AtomicBoolean midiSyncPending = new AtomicBoolean(false);
 
     /**
      * Called by JavaFX to initialise the controller after its root element has been processed.
@@ -170,13 +176,13 @@ public class SynthUIController implements Initializable {
         // Oscillator Controls
         waveformChoiceBox.setItems(FXCollections.observableArrayList(Synthesiser.Waveform.values()));
         waveformChoiceBox.getSelectionModel().selectedItemProperty().addListener((obs, o, n) -> {
-            if (n != null) synth.setOscillatorWaveform(n);
+            if (n != null && !syncingFromMidi) synth.setOscillatorWaveform(n);
         });
 
         // LFO Controls
         lfoWaveformChoiceBox.setItems(FXCollections.observableArrayList(Synthesiser.Waveform.values()));
         lfoWaveformChoiceBox.getSelectionModel().selectedItemProperty().addListener((obs, o, n) -> {
-            if (n != null) synth.setLFOWaveform(n);
+            if (n != null && !syncingFromMidi) synth.setLFOWaveform(n);
         });
 
         setupLFOControls();
@@ -193,7 +199,7 @@ public class SynthUIController implements Initializable {
     private void setupLFOControls() {
         lfoFrequencySlider.valueProperty().addListener((obs, o, n) -> {
             double freq = n.doubleValue();
-            synth.setLFOFrequency(freq);
+            if (!syncingFromMidi) synth.setLFOFrequency(freq);
             lfoFrequencyLabel.setText(frequencyFormat.format(freq) + " Hz");
         });
     }
@@ -214,28 +220,28 @@ public class SynthUIController implements Initializable {
         // Amp envelope
         ampEnvelopeVisualizer.attackTimeProperty().addListener((obs, o, n) -> {
             double attack = n.doubleValue();
-            synth.setAmpAttackTime(attack);
+            if (!syncingFromMidi) synth.setAmpAttackTime(attack);
             ampAttackSlider.setValue(attack);
             ampAttackLabel.setText(timeFormat.format(attack) + " s");
         });
         
         ampEnvelopeVisualizer.decayTimeProperty().addListener((obs, o, n) -> {
             double decay = n.doubleValue();
-            synth.setAmpDecayTime(decay);
+            if (!syncingFromMidi) synth.setAmpDecayTime(decay);
             ampDecaySlider.setValue(decay);
             ampDecayLabel.setText(timeFormat.format(decay) + " s");
         });
         
         ampEnvelopeVisualizer.sustainLevelProperty().addListener((obs, o, n) -> {
             double sustain = n.doubleValue();
-            synth.setAmpSustainLevel(sustain);
+            if (!syncingFromMidi) synth.setAmpSustainLevel(sustain);
             ampSustainSlider.setValue(sustain);
             ampSustainLabel.setText(levelFormat.format(sustain));
         });
         
         ampEnvelopeVisualizer.releaseTimeProperty().addListener((obs, o, n) -> {
             double release = n.doubleValue();
-            synth.setAmpReleaseTime(release);
+            if (!syncingFromMidi) synth.setAmpReleaseTime(release);
             ampReleaseSlider.setValue(release);
             ampReleaseLabel.setText(timeFormat.format(release) + " s");
         });
@@ -243,28 +249,28 @@ public class SynthUIController implements Initializable {
         // Filter envelope
         filterEnvelopeVisualizer.attackTimeProperty().addListener((obs, o, n) -> {
             double attack = n.doubleValue();
-            synth.setFilterAttackTime(attack);
+            if (!syncingFromMidi) synth.setFilterAttackTime(attack);
             filterAttackSlider.setValue(attack);
             filterAttackLabel.setText(timeFormat.format(attack) + " s");
         });
         
         filterEnvelopeVisualizer.decayTimeProperty().addListener((obs, o, n) -> {
             double decay = n.doubleValue();
-            synth.setFilterDecayTime(decay);
+            if (!syncingFromMidi) synth.setFilterDecayTime(decay);
             filterDecaySlider.setValue(decay);
             filterDecayLabel.setText(timeFormat.format(decay) + " s");
         });
         
         filterEnvelopeVisualizer.sustainLevelProperty().addListener((obs, o, n) -> {
             double sustain = n.doubleValue();
-            synth.setFilterSustainLevel(sustain);
+            if (!syncingFromMidi) synth.setFilterSustainLevel(sustain);
             filterSustainSlider.setValue(sustain);
             filterSustainLabel.setText(levelFormat.format(sustain));
         });
         
         filterEnvelopeVisualizer.releaseTimeProperty().addListener((obs, o, n) -> {
             double release = n.doubleValue();
-            synth.setFilterReleaseTime(release);
+            if (!syncingFromMidi) synth.setFilterReleaseTime(release);
             filterReleaseSlider.setValue(release);
             filterReleaseLabel.setText(timeFormat.format(release) + " s");
         });
@@ -276,19 +282,19 @@ public class SynthUIController implements Initializable {
     private void setupFilterControls() {
         filterCutoffSlider.valueProperty().addListener((obs, o, n) -> {
             double cutoff = n.doubleValue();
-            synth.setFilterCutoff(cutoff);
+            if (!syncingFromMidi) synth.setFilterCutoff(cutoff);
             filterCutoffLabel.setText(integerFormat.format(cutoff) + " Hz");
         });
         
         filterResonanceSlider.valueProperty().addListener((obs, o, n) -> {
             double resonance = n.doubleValue();
-            synth.setFilterResonance(resonance);
+            if (!syncingFromMidi) synth.setFilterResonance(resonance);
             filterResonanceLabel.setText(frequencyFormat.format(resonance));
         });
         
         filterModRangeSlider.valueProperty().addListener((obs, o, n) -> {
             double modRange = n.doubleValue();
-            synth.setFilterModRange(modRange);
+            if (!syncingFromMidi) synth.setFilterModRange(modRange);
             filterModRangeLabel.setText(integerFormat.format(modRange) + " Hz");
         });
     }
@@ -299,28 +305,28 @@ public class SynthUIController implements Initializable {
     private void setupAmpEnvelopeControls() {
         ampAttackSlider.valueProperty().addListener((obs, o, n) -> {
             double attack = n.doubleValue();
-            synth.setAmpAttackTime(attack);
+            if (!syncingFromMidi) synth.setAmpAttackTime(attack);
             ampEnvelopeVisualizer.setAttackTime(attack);
             ampAttackLabel.setText(timeFormat.format(attack) + " s");
         });
         
         ampDecaySlider.valueProperty().addListener((obs, o, n) -> {
             double decay = n.doubleValue();
-            synth.setAmpDecayTime(decay);
+            if (!syncingFromMidi) synth.setAmpDecayTime(decay);
             ampEnvelopeVisualizer.setDecayTime(decay);
             ampDecayLabel.setText(timeFormat.format(decay) + " s");
         });
         
         ampSustainSlider.valueProperty().addListener((obs, o, n) -> {
             double sustain = n.doubleValue();
-            synth.setAmpSustainLevel(sustain);
+            if (!syncingFromMidi) synth.setAmpSustainLevel(sustain);
             ampEnvelopeVisualizer.setSustainLevel(sustain);
             ampSustainLabel.setText(levelFormat.format(sustain));
         });
         
         ampReleaseSlider.valueProperty().addListener((obs, o, n) -> {
             double release = n.doubleValue();
-            synth.setAmpReleaseTime(release);
+            if (!syncingFromMidi) synth.setAmpReleaseTime(release);
             ampEnvelopeVisualizer.setReleaseTime(release);
             ampReleaseLabel.setText(timeFormat.format(release) + " s");
         });
@@ -332,28 +338,28 @@ public class SynthUIController implements Initializable {
     private void setupFilterEnvelopeControls() {
         filterAttackSlider.valueProperty().addListener((obs, o, n) -> {
             double attack = n.doubleValue();
-            synth.setFilterAttackTime(attack);
+            if (!syncingFromMidi) synth.setFilterAttackTime(attack);
             filterEnvelopeVisualizer.setAttackTime(attack);
             filterAttackLabel.setText(timeFormat.format(attack) + " s");
         });
         
         filterDecaySlider.valueProperty().addListener((obs, o, n) -> {
             double decay = n.doubleValue();
-            synth.setFilterDecayTime(decay);
+            if (!syncingFromMidi) synth.setFilterDecayTime(decay);
             filterEnvelopeVisualizer.setDecayTime(decay);
             filterDecayLabel.setText(timeFormat.format(decay) + " s");
         });
         
         filterSustainSlider.valueProperty().addListener((obs, o, n) -> {
             double sustain = n.doubleValue();
-            synth.setFilterSustainLevel(sustain);
+            if (!syncingFromMidi) synth.setFilterSustainLevel(sustain);
             filterEnvelopeVisualizer.setSustainLevel(sustain);
             filterSustainLabel.setText(levelFormat.format(sustain));
         });
         
         filterReleaseSlider.valueProperty().addListener((obs, o, n) -> {
             double release = n.doubleValue();
-            synth.setFilterReleaseTime(release);
+            if (!syncingFromMidi) synth.setFilterReleaseTime(release);
             filterEnvelopeVisualizer.setReleaseTime(release);
             filterReleaseLabel.setText(timeFormat.format(release) + " s");
         });
@@ -366,25 +372,25 @@ public class SynthUIController implements Initializable {
         masterVolumeSlider.valueProperty().addListener((obs, o, n) -> {
             double volume = n.doubleValue();
             currentMasterVolume = volume;
-            synth.setMasterVolume(volume);
+            if (!syncingFromMidi) synth.setMasterVolume(volume);
             masterVolumeLabel.setText(percentFormat.format(volume * 100) + "%");
         });
         
         panDepthSlider.valueProperty().addListener((obs, o, n) -> {
             double panDepth = n.doubleValue();
-            synth.setPanDepth(panDepth);
+            if (!syncingFromMidi) synth.setPanDepth(panDepth);
             panDepthLabel.setText(levelFormat.format(panDepth));
         });
         
         preFilterGainSlider.valueProperty().addListener((obs, o, n) -> {
             double gain = n.doubleValue();
-            synth.setPreFilterGainDB(gain);
+            if (!syncingFromMidi) synth.setPreFilterGainDB(gain);
             preFilterGainLabel.setText(decibelsFormat.format(gain) + " dB");
         });
         
         postFilterGainSlider.valueProperty().addListener((obs, o, n) -> {
             double gain = n.doubleValue();
-            synth.setPostFilterGainDB(gain);
+            if (!syncingFromMidi) synth.setPostFilterGainDB(gain);
             postFilterGainLabel.setText(decibelsFormat.format(gain) + " dB");
         });
     }
@@ -521,7 +527,25 @@ public class SynthUIController implements Initializable {
         if (midiDevice != null && midiDevice.isOpen()) {
             midiDevice.close();
         }
-        midiDevice = MidiDeviceConnector.connectToDevice(synth, deviceName);
+        midiDevice = MidiDeviceConnector.connectToDevice(synth, deviceName, this::onMidiControlChange);
+    }
+
+    /**
+     * Called from the MIDI thread when a CC message is processed.
+     * Schedules a coalesced UI sync on the JavaFX application thread.
+     */
+    private void onMidiControlChange() {
+        if (midiSyncPending.compareAndSet(false, true)) {
+            Platform.runLater(() -> {
+                syncingFromMidi = true;
+                try {
+                    syncUIWithSynthSettings();
+                } finally {
+                    syncingFromMidi = false;
+                    midiSyncPending.set(false);
+                }
+            });
+        }
     }
 
     /**

--- a/src/main/java/synth/ui/SynthUIController.java
+++ b/src/main/java/synth/ui/SynthUIController.java
@@ -135,7 +135,12 @@ public class SynthUIController implements Initializable {
 
         setupDeviceSelectors();
         setupControls();
-        syncUIWithSynthSettings();
+        syncingFromMidi = true;
+        try {
+            syncUIWithSynthSettings();
+        } finally {
+            syncingFromMidi = false;
+        }
 
         deviceScanExecutor = Executors.newSingleThreadScheduledExecutor(r -> {
             Thread t = new Thread(r, "device-scan");
@@ -184,7 +189,7 @@ public class SynthUIController implements Initializable {
         Platform.runLater(() -> {
             if (!newMidi.equals(new ArrayList<>(midiDeviceChoiceBox.getItems()))) {
                 String selected = midiDeviceChoiceBox.getValue();
-                midiDeviceChoiceBox.setItems(FXCollections.observableArrayList(newMidi));
+                midiDeviceChoiceBox.getItems().setAll(newMidi);
                 if (newMidi.contains(selected)) {
                     midiDeviceChoiceBox.setValue(selected);
                 }
@@ -192,7 +197,7 @@ public class SynthUIController implements Initializable {
 
             if (!newAudio.equals(new ArrayList<>(audioDeviceChoiceBox.getItems()))) {
                 String selected = audioDeviceChoiceBox.getValue();
-                audioDeviceChoiceBox.setItems(FXCollections.observableArrayList(newAudio));
+                audioDeviceChoiceBox.getItems().setAll(newAudio);
                 if (newAudio.contains(selected)) {
                     audioDeviceChoiceBox.setValue(selected);
                 }

--- a/src/main/java/synth/ui/SynthUIController.java
+++ b/src/main/java/synth/ui/SynthUIController.java
@@ -14,11 +14,14 @@ import javax.sound.sampled.AudioFormat;
 import javax.sound.sampled.LineUnavailableException;
 import javax.sound.sampled.SourceDataLine;
 
+import javafx.animation.KeyFrame;
+import javafx.animation.Timeline;
 import javafx.application.Platform;
 import javafx.collections.FXCollections;
 import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
 import javafx.scene.control.ChoiceBox;
+import javafx.util.Duration;
 import javafx.scene.control.Label;
 import javafx.scene.control.Slider;
 import javafx.scene.layout.VBox;
@@ -114,6 +117,8 @@ public class SynthUIController implements Initializable {
     // Track master volume since synth doesn't have a getter
     private double currentMasterVolume = 1.0;
     
+    private Timeline deviceScanTimeline;
+
     // Flag to prevent redundant synth calls when syncing UI from MIDI CC
     private boolean syncingFromMidi = false;
     // Coalescing flag for MIDI CC UI sync
@@ -135,6 +140,10 @@ public class SynthUIController implements Initializable {
         setupDeviceSelectors();
         setupControls();
         syncUIWithSynthSettings();
+
+        deviceScanTimeline = new Timeline(new KeyFrame(Duration.seconds(AudioConstants.DEVICE_SCAN_INTERVAL_SECONDS), e -> refreshDeviceLists()));
+        deviceScanTimeline.setCycleCount(Timeline.INDEFINITE);
+        deviceScanTimeline.play();
     }
 
     /**
@@ -142,7 +151,7 @@ public class SynthUIController implements Initializable {
      */
     private void setupDeviceSelectors() {
         // Audio Devices
-        ArrayList<String> audioDevices = AudioDeviceConnector.getAudioOutputDeviceList();
+        ArrayList<String> audioDevices = AudioDeviceConnector.getAudioOutputDeviceList(true);
         audioDeviceChoiceBox.setItems(FXCollections.observableArrayList(audioDevices));
         audioDeviceChoiceBox.getSelectionModel().selectedItemProperty().addListener((obs, oldDevice, newDevice) -> {
             if (newDevice != null) {
@@ -151,7 +160,7 @@ public class SynthUIController implements Initializable {
         });
 
         // MIDI Devices
-        ArrayList<String> midiDevices = MidiDeviceConnector.getMidiDevicesList();
+        ArrayList<String> midiDevices = MidiDeviceConnector.getMidiDevicesList(true);
         midiDeviceChoiceBox.setItems(FXCollections.observableArrayList(midiDevices));
         midiDeviceChoiceBox.getSelectionModel().selectedItemProperty().addListener((obs, oldDevice, newDevice) -> {
             if (newDevice != null) {
@@ -165,6 +174,26 @@ public class SynthUIController implements Initializable {
         }
         if (!midiDevices.isEmpty()) {
             midiDeviceChoiceBox.getSelectionModel().selectFirst();
+        }
+    }
+
+    private void refreshDeviceLists() {
+        ArrayList<String> newMidi = MidiDeviceConnector.getMidiDevicesList();
+        if (!newMidi.equals(new ArrayList<>(midiDeviceChoiceBox.getItems()))) {
+            String selected = midiDeviceChoiceBox.getValue();
+            midiDeviceChoiceBox.setItems(FXCollections.observableArrayList(newMidi));
+            if (newMidi.contains(selected)) {
+                midiDeviceChoiceBox.setValue(selected);
+            }
+        }
+
+        ArrayList<String> newAudio = AudioDeviceConnector.getAudioOutputDeviceList();
+        if (!newAudio.equals(new ArrayList<>(audioDeviceChoiceBox.getItems()))) {
+            String selected = audioDeviceChoiceBox.getValue();
+            audioDeviceChoiceBox.setItems(FXCollections.observableArrayList(newAudio));
+            if (newAudio.contains(selected)) {
+                audioDeviceChoiceBox.setValue(selected);
+            }
         }
     }
 
@@ -628,6 +657,10 @@ public class SynthUIController implements Initializable {
      * Safely closes audio and MIDI resources when the application exits.
      */
     public void shutdown() {
+        if (deviceScanTimeline != null) {
+            deviceScanTimeline.stop();
+        }
+
         // Stop the audio thread
         if (audioThread != null && audioThread.isAlive()) {
             audioThreadRunning = false;

--- a/src/main/java/synth/ui/SynthUIController.java
+++ b/src/main/java/synth/ui/SynthUIController.java
@@ -114,9 +114,6 @@ public class SynthUIController implements Initializable {
     @FXML private Slider postFilterGainSlider;
     @FXML private Label postFilterGainLabel;
     
-    // Track master volume since synth doesn't have a getter
-    private double currentMasterVolume = 1.0;
-    
     private Timeline deviceScanTimeline;
 
     // Flag to prevent redundant synth calls when syncing UI from MIDI CC
@@ -400,7 +397,6 @@ public class SynthUIController implements Initializable {
     private void setupGlobalControls() {
         masterVolumeSlider.valueProperty().addListener((obs, o, n) -> {
             double volume = n.doubleValue();
-            currentMasterVolume = volume;
             if (!syncingFromMidi) synth.setMasterVolume(volume);
             masterVolumeLabel.setText(percentFormat.format(volume * 100) + "%");
         });
@@ -466,7 +462,6 @@ public class SynthUIController implements Initializable {
         
         // Global Control settings
         masterVolumeSlider.setValue(synth.getMasterVolumeScalar());
-        currentMasterVolume = synth.getMasterVolumeScalar();
         panDepthSlider.setValue(synth.getPanDepth());
         preFilterGainSlider.setValue(synth.getPreFilterGainDB());
         postFilterGainSlider.setValue(synth.getPostFilterGainDB());

--- a/src/main/java/synth/utils/AudioConstants.java
+++ b/src/main/java/synth/utils/AudioConstants.java
@@ -4,6 +4,7 @@ public interface AudioConstants {
     double SAMPLE_RATE = 44100.0;
     int BLOCK_SIZE = 256;
     int BUFFER_SIZE =  BLOCK_SIZE * 8;
-    int NUMBER_OF_VOICES = 6;
+    int NUMBER_OF_VOICES = 8;
     int LOOKUP_TABLE_SIZE = 16384*2;
+    double DEVICE_SCAN_INTERVAL_SECONDS = 3.0;
 }

--- a/src/main/java/synth/utils/AudioDeviceConnector.java
+++ b/src/main/java/synth/utils/AudioDeviceConnector.java
@@ -11,8 +11,9 @@ import java.util.Scanner;
 public class AudioDeviceConnector {
 
     /**
-     * Lists all available audio output devices to the console.
+     * Returns all available audio output device names.
      * An output device is a mixer that can provide a SourceDataLine.
+     * Equivalent to {@code getAudioOutputDeviceList(false)} (no console output).
      * @return An ArrayList of strings, where each string is the name of an available device.
      */
     public static ArrayList<String> getAudioOutputDeviceList() {

--- a/src/main/java/synth/utils/AudioDeviceConnector.java
+++ b/src/main/java/synth/utils/AudioDeviceConnector.java
@@ -36,6 +36,9 @@ public class AudioDeviceConnector {
                     i++;
                 }
             } catch (Exception e) {
+                if (verbose) {
+                    System.err.println("Skipping audio device '" + info.getName() + "': " + e.getMessage());
+                }
             }
         }
         if (verbose) System.out.println("------------------------------------");

--- a/src/main/java/synth/utils/AudioDeviceConnector.java
+++ b/src/main/java/synth/utils/AudioDeviceConnector.java
@@ -16,27 +16,28 @@ public class AudioDeviceConnector {
      * @return An ArrayList of strings, where each string is the name of an available device.
      */
     public static ArrayList<String> getAudioOutputDeviceList() {
+        return getAudioOutputDeviceList(false);
+    }
+
+    public static ArrayList<String> getAudioOutputDeviceList(boolean verbose) {
         ArrayList<String> devices = new ArrayList<>();
-        System.out.println("--- Select Audio Output Device ---");
+        if (verbose) System.out.println("--- Select Audio Output Device ---");
         int i = 1;
         for (Mixer.Info info : AudioSystem.getMixerInfo()) {
-            // Filter to skip devices starting with "Port "
             if (info.getName().startsWith("Port ")) {
                 continue;
             }
             try {
                 Mixer mixer = AudioSystem.getMixer(info);
-                // Check if the mixer supports output (SourceDataLine)
                 if (mixer.getSourceLineInfo().length > 0) {
                     devices.add(info.getName());
-                    System.out.println(i + "- " + info.getName());
+                    if (verbose) System.out.println(i + "- " + info.getName());
                     i++;
                 }
             } catch (Exception e) {
-                // Ignore devices that can't be accessed
             }
         }
-        System.out.println("------------------------------------");
+        if (verbose) System.out.println("------------------------------------");
         return devices;
     }
 
@@ -46,7 +47,7 @@ public class AudioDeviceConnector {
      * @return The name of the selected audio device, or null if none are found.
      */
     public static String promptUser() {
-        ArrayList<String> devices = getAudioOutputDeviceList();
+        ArrayList<String> devices = getAudioOutputDeviceList(true);
         if (devices.isEmpty()) {
             System.out.println("No audio output devices available.");
             return null;


### PR DESCRIPTION
This pull request introduces significant improvements to the thread safety and efficiency of the `Synthesiser` class, as well as enhances flexibility in MIDI device handling. The main changes involve switching to a "pull" model for syncing parameter updates to voices, using atomic flags and `volatile` fields for thread safety, and refactoring MIDI device selection and connection methods for better usability.

**Synthesiser Thread Safety and Parameter Syncing:**

- **Pull Model for Parameter Syncing:** Parameter setters no longer update all voices immediately. Instead, they set atomic "dirty" flags, and the audio thread (in `processBlock`) syncs only the changed parameters to all voices once per audio block. This reduces lock contention and ensures consistent updates. (`Synthesiser.java`) [[1]](diffhunk://#diff-dd4dd9792fe1d2356a90111fbea4468b7cbeb81f6c74e81e4122ff6e3ee4c6e5R16-R68) [[2]](diffhunk://#diff-dd4dd9792fe1d2356a90111fbea4468b7cbeb81f6c74e81e4122ff6e3ee4c6e5R153-R163) [[3]](diffhunk://#diff-dd4dd9792fe1d2356a90111fbea4468b7cbeb81f6c74e81e4122ff6e3ee4c6e5R437-R494)
- **Thread Safety Improvements:** Key synthesiser parameters are now declared `volatile`, and atomic flags (`AtomicBoolean`) are used for each parameter group (e.g., waveform, filter, envelopes, gain, pan). This makes parameter changes from the UI thread safe and predictable with respect to the audio thread. (`Synthesiser.java`)
- **LFO Handling Refactor:** The LFO waveform and frequency are now set exclusively in the audio thread, ensuring thread safety and avoiding race conditions. The setter for LFO waveform only marks the change, and the update happens in `processBlock`. (`Synthesiser.java`) [[1]](diffhunk://#diff-dd4dd9792fe1d2356a90111fbea4468b7cbeb81f6c74e81e4122ff6e3ee4c6e5R139-L136) [[2]](diffhunk://#diff-dd4dd9792fe1d2356a90111fbea4468b7cbeb81f6c74e81e4122ff6e3ee4c6e5R437-R494)

**Parameter Validation and Range Enforcement:**

- **Improved Parameter Validation:** Setter methods now include additional null checks and range clamping, including filter cutoff being limited by the sample rate, and waveform/LFO waveform setters throwing exceptions on null input. (`Synthesiser.java`) [[1]](diffhunk://#diff-dd4dd9792fe1d2356a90111fbea4468b7cbeb81f6c74e81e4122ff6e3ee4c6e5R153-R163) [[2]](diffhunk://#diff-dd4dd9792fe1d2356a90111fbea4468b7cbeb81f6c74e81e4122ff6e3ee4c6e5L163-R247)

**MIDI Device Handling Enhancements:**

- **Verbose and Flexible Device Listing:** The MIDI device listing and prompt methods are refactored to support a "verbose" option for console output, and always return a list (never null). (`MidiDeviceConnector.java`) [[1]](diffhunk://#diff-a91911350b848fff7c72e00e11e4de9fb0b5162f4cc7e0ab4139ca87b245c607R22-R45) [[2]](diffhunk://#diff-a91911350b848fff7c72e00e11e4de9fb0b5162f4cc7e0ab4139ca87b245c607L46-R56)
- **Callback Support for Control Changes:** The MIDI device connection method now supports an optional callback (`Runnable onControlChange`) for handling MIDI control changes, improving integration flexibility. (`MidiDeviceConnector.java`)

These changes collectively improve the reliability, efficiency, and maintainability of the synthesiser engine and MIDI integration.This pull request introduces significant improvements to the `Synthesiser` class and its MIDI integration, focusing on thread safety, parameter update efficiency, and MIDI control extensibility. The main changes include making synthesiser parameters thread-safe, implementing a "dirty flag" mechanism for efficient parameter synchronisation, and adding support for MIDI control change callbacks.

**Thread safety and parameter synchronisation:**

* Declared key synthesiser parameters (such as waveform, filter, envelope, gain, and LFO settings) as `volatile` to ensure thread-safe access between the audio and UI threads. Introduced per-parameter-group "dirty flags" (e.g., `waveformDirty`, `filterDirty`) that are set in setters and cleared in the audio thread after syncing changes to all voices. This replaces the previous eager update approach with a pull-based model, improving performance and reducing contention. [[1]](diffhunk://#diff-dd4dd9792fe1d2356a90111fbea4468b7cbeb81f6c74e81e4122ff6e3ee4c6e5L21-R65) [[2]](diffhunk://#diff-dd4dd9792fe1d2356a90111fbea4468b7cbeb81f6c74e81e4122ff6e3ee4c6e5L148-R153) [[3]](diffhunk://#diff-dd4dd9792fe1d2356a90111fbea4468b7cbeb81f6c74e81e4122ff6e3ee4c6e5L164-R232) [[4]](diffhunk://#diff-dd4dd9792fe1d2356a90111fbea4468b7cbeb81f6c74e81e4122ff6e3ee4c6e5R424-R472) [[5]](diffhunk://#diff-dd4dd9792fe1d2356a90111fbea4468b7cbeb81f6c74e81e4122ff6e3ee4c6e5R500-R551)

* The LFO waveform and frequency are now synchronised at the start of each audio block, ensuring the audio thread is the sole consumer of the LFO object and eliminating race conditions. [[1]](diffhunk://#diff-dd4dd9792fe1d2356a90111fbea4468b7cbeb81f6c74e81e4122ff6e3ee4c6e5R104) [[2]](diffhunk://#diff-dd4dd9792fe1d2356a90111fbea4468b7cbeb81f6c74e81e4122ff6e3ee4c6e5L128-L136) [[3]](diffhunk://#diff-dd4dd9792fe1d2356a90111fbea4468b7cbeb81f6c74e81e4122ff6e3ee4c6e5R424-R472) [[4]](diffhunk://#diff-dd4dd9792fe1d2356a90111fbea4468b7cbeb81f6c74e81e4122ff6e3ee4c6e5R500-R551)

**MIDI integration and extensibility:**

* Extended `MidiDeviceConnector.connectToDevice` to accept an optional `Runnable` callback (`onControlChange`) that is invoked after a MIDI control change (CC) message is processed. This enables external components (such as GUIs) to react immediately to MIDI-driven parameter changes. [[1]](diffhunk://#diff-a91911350b848fff7c72e00e11e4de9fb0b5162f4cc7e0ab4139ca87b245c607R88-R98) [[2]](diffhunk://#diff-a91911350b848fff7c72e00e11e4de9fb0b5162f4cc7e0ab4139ca87b245c607L92-R108) [[3]](diffhunk://#diff-42fdb14e65f28486ff0c7ae34ac97c08f5737385cc3c5883553b560aea3aceaeR15-R35)

* Updated `MidiInputHandler` to accept and invoke the `onControlChange` callback after handling CC messages, and fixed a bug where the post-filter gain was incorrectly set via the pre-filter setter. [[1]](diffhunk://#diff-42fdb14e65f28486ff0c7ae34ac97c08f5737385cc3c5883553b560aea3aceaeR15-R35) [[2]](diffhunk://#diff-42fdb14e65f28486ff0c7ae34ac97c08f5737385cc3c5883553b560aea3aceaeL135-R156)

**Code hygiene and test improvements:**

* Improved imports and structure in `MidiDeviceConnector` for clarity and correctness.
* Enhanced the `PerformanceTest` to include a contention stress test, helping to validate thread safety under concurrent parameter updates.

These changes collectively improve the safety, efficiency, and extensibility of the synthesiser's core and MIDI handling.

Closes #2 